### PR TITLE
Trusty fixes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -208,6 +208,18 @@
 
 ## (ref. debian/postinst)
 
+- name: create user archivematica
+  sudo: yes
+  user: name=archivematica uid=333 system=yes home=/var/lib/archivematica/
+  tags: amsrc-am-ss
+
+- name: create storage-service log directories
+  sudo: yes
+  file: dest={{ item }} state=directory owner=archivematica group=archivematica
+  with_items:
+    - /var/log/archivematica/storage-service
+  tags: amsrc-am-ss
+
 - name: call the debian/postinst script for archivematica-storage-service
   sudo: yes
   command: chdir=/srv/archivematica-storage-service/debian/ executable=/bin/bash source postinst
@@ -370,6 +382,18 @@
 
 ## (ref. debian/postinst )
 
+- name: create user archivematica
+  sudo: yes
+  user: name=archivematica uid=333 system=yes home=/var/lib/archivematica/
+  tags: amsrc-am-mcp-server
+
+- name: create mcp-server log directories
+  sudo: yes
+  file: dest={{ item }} state=directory owner=archivematica group=archivematica mode=g+s
+  with_items:
+    - /var/log/archivematica/MCPServer
+  tags: amsrc-am-mcp-server
+
 - name: create /var/archivematica/sharedDirectory
   sudo: yes
   file: dest=/var/archivematica/sharedDirectory state=directory 
@@ -503,7 +527,14 @@
 
 - name: create user archivematica
   sudo: yes
-  user: name=archivematica uid=333 group=archivematica system=yes home=/var/lib/archivematica/
+  user: name=archivematica uid=333 system=yes home=/var/lib/archivematica/
+  tags: amsrc-am-mcp-client
+
+- name: create mcp-client log directories
+  sudo: yes
+  file: dest={{ item }} state=directory owner=archivematica group=archivematica mode=g+s
+  with_items:
+    - /var/log/archivematica/MCPClient
   tags: amsrc-am-mcp-client
 
 
@@ -568,6 +599,18 @@
 
 - name: set MCP database charset
   command: mysql -u archivematica -pdemo MCP -e 'alter database MCP CHARACTER SET utf8 COLLATE utf8_unicode_ci'
+  tags: amsrc-am-dashboard
+
+- name: create user archivematica
+  sudo: yes
+  user: name=archivematica uid=333 system=yes home=/var/lib/archivematica/
+  tags: amsrc-am-dashboard
+
+- name: create dashboard log directories
+  sudo: yes
+  file: dest={{ item }} state=directory owner=archivematica group=archivematica mode=g+s
+  with_items:
+    - /var/log/archivematica/dashboard
   tags: amsrc-am-dashboard
 
 - name: django syncdb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,17 @@
     - amsrc-am-mcp-client
     - amsrc-am-ss
 
+- name: Add Universe repository
+  sudo: yes
+  apt_repository: repo='{{ item }}' state=present
+  with_items:
+    - "deb http://archive.ubuntu.com/ubuntu/ {{ ansible_distribution_release }} main restricted universe multiverse"
+    - "deb http://archive.ubuntu.com/ubuntu/ {{ ansible_distribution_release }}-security main restricted universe"
+    - "deb http://archive.ubuntu.com/ubuntu/ {{ ansible_distribution_release }}-updates main restricted universe multiverse"
+  tags:
+    - amsrc-am-common
+    - amsrc-am-mcp-client
+
   
 
 #########################################################

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -615,6 +615,9 @@
 - name: django syncdb
   command: /usr/share/archivematica/dashboard/manage.py syncdb --settings='settings.common'
   tags: amsrc-am-dashboard
+
+- name: call mysql_dev script
+  command: chdir=/srv/archivematica/src/MCPServer/share/ ./mysql_dev.sh MCP
   
 - name: create archivematicaDashboard.log
   file: name=/tmp/archivematicaDashboard.log mode=666 state=touch

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -633,7 +633,7 @@
 
 
 - name: copy apache config file  
-  copy: src=apache.default dest=/etc/apache2/sites-available/default  owner=root group=root mode=644
+  copy: src=apache.default dest=/etc/apache2/sites-available/default.conf  owner=root group=root mode=644
   sudo: yes
   notify: restart apache2
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -408,7 +408,7 @@
 
 - name: create user archivematica
   sudo: yes
-  user: name=archivematica uid=333 group=archivematica system=yes home=/var/lib/archivematica/
+  user: name=archivematica uid=333 system=yes home=/var/lib/archivematica/
   tags: amsrc-am-mcp-client
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -507,7 +507,6 @@
     - python-lxml
     - python-mysqldb
     - python-pyicu
-    - python-rfc6266
     - python-unidecode
     - readpst
     - rsync


### PR DESCRIPTION
This adds the following fixes I needed to be able to install on Trusty and with current versions of qa/1.x.

- [ ] Add Universe repository

This may not be enabled by default, and is a requirement for installing the JHOVE package for MCPClient.

- [ ] Create /var/log/archivematica directories 

- [ ] Remove python-rfc6266 package

This is no longer used by Archivematica and, since it’s not packaged for Trusty, also prevents the packages from being installed on 14.04.

- [ ]  Change name of apache sites-available default.conf file 

@hakamine mentioned needing to do this on 14.04, but I don't know if it breaks 12.04.