### PR TITLE
Specify --noinput when calling syncdb

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -610,7 +610,7 @@
   tags: amsrc-am-dashboard
 
 - name: django syncdb
-  command: /usr/share/archivematica/dashboard/manage.py syncdb --settings='settings.common'
+  command: /usr/share/archivematica/dashboard/manage.py syncdb --settings='settings.common' --noinput
   tags: amsrc-am-dashboard
 
 - name: call mysql_dev script


### PR DESCRIPTION
Without passing this option, the script may attempt to prompt a user for action, which will hang forever since this is running in a script.