### PR TITLE
[WIP] Environment type enhancements

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,8 @@ archivematica_src_dir: "{{ ansible_env.HOME }}"
 archivematica_src_install_sample_data: "yes"
 
 # Define the type of environment: "production" or "development". The latter
-# will deploy some extra stuff to make the development workflow easier.
+# will deploy some extra stuff to make the development workflow easier like
+# environment variables or different dependencies, tools, etc...
 archivematica_src_environment_type: "production"
 
 # Branches, TODO: canonize keys ala "archivematica_src_..."


### PR DESCRIPTION
This PR tries to address #6.

Look up the value of `archivematica_src_environment_type` (added in `dev/issue-xxxx-splitting-main-yml` but still unused) and proceed differently depending on its value ("production" or "development"), e.g. for development environments:
- Install https://github.com/artefactual/archivematica-devtools
- Create virtual environments using local.txt instead of prod.txt for the different applications
- Auto-reload code (uWSGI and mod_python) - so restart service is not needed
- Some defaults for bash like a prompt with current git branch
- Install fish
- Application environment switcher tool (see https://wiki.archivematica.org/Getting_started#Tests)
- Friendly MOTD with links to development documentation
