### PR TITLE
Don't run freshclam on installation

### DIFF
--- a/tasks/archivematica-mcp-client.yml
+++ b/tasks/archivematica-mcp-client.yml
@@ -96,8 +96,30 @@
     job: "/usr/bin/freshclam"
     state: "present"
 
-- name: "Download clamav signatures"
-  command: "freshclam"
+# Have found that installation often stalls in freshclam
+# Will download signatures from our repo to try to avoid this
+#- name: "Download clamav signatures"
+#  command: "freshclam"
+
+- name: "Get clamav signatures from github repo"
+  git:
+    repo=https://github.com/artefactual-labs/clamav-files.git
+    dest=/tmp/clamav-files
+- name: "Copy clamav signatures to /var/lib/clamav"
+  command: cp /tmp/clamav-files/{{ item }} /var/lib/clamav/
+  sudo: yes
+  with_items:
+    - bytecode.cvd
+    - daily.cvd
+    - main.cvd
+    - mirrors.dat
+- name: "Set user permissions for clamav files"
+  file:
+    path=/var/lib/clamav
+    owner=clamav
+    group=clamav
+    state=directory
+    recurse=yes
 
 - name: "Enable services"
   service:

--- a/tasks/archivematica-mcp-client.yml
+++ b/tasks/archivematica-mcp-client.yml
@@ -88,23 +88,52 @@
   with_items:
     - "/var/log/archivematica/MCPClient"
 
-- name: "Daily clamav database update"
-  cron:
-    name: "Daily clamav database update"
-    hour: "2"
-    minute: "0"
-    job: "/usr/bin/freshclam"
-    state: "present"
+
+# crontab seems not required for freshclam updates
+# freshclam is executed hourly by default (clamav-freshclam)
+#- name: "Daily clamav database update"
+#  cron:
+#    name: "Daily clamav database update"
+#    hour: "2"
+#    minute: "0"
+#    job: "/usr/bin/freshclam"
+#    state: "present"
 
 # Have found that installation often stalls in freshclam
 # Will download signatures from our repo to try to avoid this
+
 #- name: "Download clamav signatures"
 #  command: "freshclam"
 
-- name: "Get clamav signatures from github repo"
+
+# check if clamav files exist already
+- stat: path=/var/lib/clamav/bytecode.cvd
+  register: clamf1
+- stat: path=/var/lib/clamav/bytecode.cld
+  register: clamf1a
+
+- stat: path=/var/lib/clamav/daily.cvd
+  register: clamf2
+- stat: path=/var/lib/clamav/daily.cld
+  register: clamf2a
+
+- stat: path=/var/lib/clamav/main.cvd
+  register: clamf3
+- stat: path=/var/lib/clamav/main.cld
+  register: clamf3a
+
+- set_fact:
+    clamav_download: "{{ not ( ( clamf1.stat.exists or clamf1a.stat.exists ) and
+                               ( clamf2.stat.exists or clamf2a.stat.exists ) and
+                               ( clamf3.stat.exists or clamf3a.stat.exists ) ) }}"
+- debug: msg="Need to download clamav signatures"
+  when: clamav_download
+
+- name: "Get clamav signatures from our github repo"
   git:
     repo=https://github.com/artefactual-labs/clamav-files.git
     dest=/tmp/clamav-files
+  when: clamav_download
 - name: "Copy clamav signatures to /var/lib/clamav"
   command: cp /tmp/clamav-files/{{ item }} /var/lib/clamav/
   sudo: yes
@@ -112,14 +141,16 @@
     - bytecode.cvd
     - daily.cvd
     - main.cvd
-    - mirrors.dat
-- name: "Set user permissions for clamav files"
+  when: clamav_download
+
+- name: "Set user ownership for clamav files"
   file:
     path=/var/lib/clamav
     owner=clamav
     group=clamav
     state=directory
     recurse=yes
+  when: clamav_download
 
 - name: "Enable services"
   service:


### PR DESCRIPTION
freshclam stalls often (probably caused by clamav
server issues) when run by this role.
As a workaround, download the clamav signatures
from a github repo to avoid the need to run freshclam.
The signature files are recent but not guaranteed
to be the latest ones, however those should be
updated by freshclam later.