### PR TITLE
Add tasks to re-create MCP database

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ N/A yet.
 Role Variables
 --------------
 
-N/A yet.
+`archivematica_src_reset_mcpdb`: set to true to re-create the MCP database (normally at runtime using `ansible-playbook` `--extra-vars` switch)
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,3 +28,6 @@ archivematica_src_ss_env_ss_db_host: ""
 archivematica_src_ss_env_ss_db_name: "/var/archivematica/storage-service/storage.db"
 archivematica_src_ss_env_ss_db_password: ""
 archivematica_src_ss_env_ss_db_user: ""
+
+# reset the MCP database (CAUTION: if yes, will lose existing MCP database data)
+archivematica_src_reset_mcpdb: "false"

--- a/tasks/pipeline-dbconf.yml
+++ b/tasks/pipeline-dbconf.yml
@@ -1,8 +1,23 @@
 
 ###########################################################
-#   5- Database config
+#   5- Database reset (when archivematica_src_reset_MCPdb: "yes")
 ###########################################################
 
+- name: "Drop MCP database"
+  mysql_db:
+    name: "MCP"
+    state: "absent"
+  when: archivematica_src_reset_mcpdb
+
+- name: "Remove mysql_dev.complete file created by mysql_dev.sh"
+  file:
+    path: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/share/mysql_dev.complete"
+    state: "absent"
+  when: archivematica_src_reset_mcpdb
+
+###########################################################
+#   5- Database config
+###########################################################
 
 # Note that when we are using mysql_db and mysql_user we are assuming that the
 # root user has a local ~/.my.cnf configuration file with the credentials in it
@@ -17,8 +32,7 @@
   register: "createdb_result"
 
 # TODO: need to change the mysql password for user archivematica
-#       but not sure if currently this could break anything
-#       (i.e., not sure if the password is hardcoded in the code)
+
 - name: "Create MySQL user"
   mysql_user:
     name: "archivematica"


### PR DESCRIPTION
Add tasks to re-create the MCP database if desired.
To run these tasks set archivematica_src_reset_mcpdb to true (default
value: false)