### PR TITLE
Make npm/bower deployment conditional

### DIFF
--- a/tasks/pipeline-deps.yml
+++ b/tasks/pipeline-deps.yml
@@ -39,19 +39,31 @@
     - "python-pip"
     - "python-gearman"
     - "python-simplejson"
+
+- name: "Check if appraisal tab is present"
+  stat: path="{{ archivematica_src_dir }}/archivematica/src/dashboard/src/external/appraisal-tab/"
+  register: appraisal_tab
+
+- name: "Install appraisal tab package dependencies"
+  apt:
+    pkg: "{{ item }}"
+    state: "latest"
+  when: appraisal_tab.stat.exists == True
+  with_items:
     - "npm"
 
 - name: "Fix install path of node vs nodejs via symlink"
   file: src=/usr/bin/nodejs dest=/usr/bin/node state=link
-
+  when: appraisal_tab.stat.exists == True
 
 - name: "Install bower"
   npm: name=bower global=yes
+  when: appraisal_tab.stat.exists == True
 
 - name: "Install bower dependencies"
   bower: path="{{ archivematica_src_dir }}/archivematica/src/dashboard/src/external/appraisal-tab/"
   sudo: no
-
+  when: appraisal_tab.stat.exists == True
 
 - name: "Install archivematica-mcp-server package dependencies"
   apt:


### PR DESCRIPTION
Only install npm and bower if the appraisal tab is present.

When deploying a 1.5.0 or earlier version of Archivematica, this commit
should produce output like this:

TASK: [archivematica-src | Check if appraisal tab is present] *****************
ok: [blewits]

TASK: [archivematica-src | Install appraisal tab package dependencies] ********
skipping: [blewits]

TASK: [archivematica-src | Fix install path of node vs nodejs via symlink] ****
skipping: [blewits]

TASK: [archivematica-src | Install bower] *************************************
skipping: [blewits]

TASK: [archivematica-src | Install bower dependencies] ************************
skipping: [blewits]