### PR TITLE
Clear sharedDirectory on MCP DB reset

### DIFF
--- a/tasks/pipeline-osconf.yml
+++ b/tasks/pipeline-osconf.yml
@@ -56,6 +56,12 @@
   with_items:
     - "/var/log/archivematica/MCPServer"
 
+- name: "Clear /var/archivematica/sharedDirectory on DB reset"
+  file:
+    dest: "/var/archivematica/sharedDirectory"
+    state: "absent"
+  when: archivematica_src_reset_mcpdb
+
 - name: "Create /var/archivematica/sharedDirectory"
   file:
     dest: "/var/archivematica/sharedDirectory"


### PR DESCRIPTION
Remove the sharedDirectory when resetting the DB, to prevent having transfers cross between installs.