### PR TITLE
Pip updates to latest version

### DIFF
--- a/tasks/archivematica-storage-service.yml
+++ b/tasks/archivematica-storage-service.yml
@@ -87,6 +87,7 @@
     requirements: "requirements.txt"
     virtualenv: "/usr/share/python/archivematica-storage-service"
     extra_args: "--find-links lib"
+    state: latest
   tags: am-src-ss-pydep
 
 ###########################################################

--- a/tasks/automation-tools.yml
+++ b/tasks/automation-tools.yml
@@ -14,6 +14,7 @@
     chdir: "{{ archivematica_src_dir }}/automation-tools"
     requirements: "requirements.txt"
     virtualenv: "/usr/share/python/automation-tools"
+    state: latest
 
 - name: "symlink automation-tools source to /usr/lib/archivematica"
   file:

--- a/tasks/pipeline-deps.yml
+++ b/tasks/pipeline-deps.yml
@@ -173,7 +173,9 @@
 - name: "Install archivematica-common pip dependencies"
   pip:
     requirements: "{{ archivematica_src_dir }}/archivematica/src/archivematicaCommon/requirements.txt"
+    state: latest
 
 - name: "Install archivematica-dashboard pip dependencies"
   pip:
     requirements: "{{ archivematica_src_dir }}/archivematica/src/dashboard/src/requirements.txt"
+    state: latest


### PR DESCRIPTION
Pip updates Python dependencies to the latest version when re-running. This will be important for the Django 1.5 -> 1.7 upgrade, though other fixes may be required for that.