### PR TITLE
MoMA specific dependencies (LDAP)

### DIFF
--- a/tasks/pipeline-deps.yml
+++ b/tasks/pipeline-deps.yml
@@ -99,6 +99,15 @@
     - "uuid"
 
 
+- name: "MoMA specific dependencies"
+  apt:
+    pkg: "{{item}}"
+    state: "latest"
+  with_items:
+    - "libsasl2-dev"
+    - "python-dev"
+    - "libldap2-dev"
+    - "libssl-dev"
 
 # Have found that installation often stalls in freshclam
 # Will download signatures from our repo to try to avoid this


### PR DESCRIPTION
Specifically for LDAP.  We may not want to merge this branch until it's generally applicable, and possibly with a rename.
