### PR TITLE
Define environment variables and PYTHONPATH in Apache 

### DIFF
--- a/templates/etc_apache2_sites_dashboard.conf.j2
+++ b/templates/etc_apache2_sites_dashboard.conf.j2
@@ -27,8 +27,13 @@
 
   # Django with mod_wsgi
   # http://code.google.com/p/modwsgi/wiki/IntegrationWithDjango
+  {% if archivematica_src_environment_type == "development" %}
+    SetEnv DJANGO_SETTINGS_MODULE settings.local
+  {% else %}
+    SetEnv DJANGO_SETTINGS_MODULE settings.common
+  {% endif %}
   WSGIScriptAlias / /usr/share/archivematica/dashboard/apache/django.wsgi
-  WSGIDaemonProcess dashboard user=archivematicadashboard group=archivematica
+  WSGIDaemonProcess dashboard user=archivematicadashboard group=archivematica python-path=/usr/share/archivematica/dashboard:/usr/lib/archivematica/archivematicaCommon
   WSGIProcessGroup dashboard
   <Directory "/usr/share/archivematica/dashboard/apache/">
     Order allow,deny


### PR DESCRIPTION
django.wsgi is part of the application, its sources are managed in the repo.
Configuration should be managed from Apache (or your fav server).

This pull request is going to be necessary once https://github.com/artefactual/archivematica/pull/358 is merged because `django.wsgi` won't provide a default `DJANGO_SETTINGS_MODULE`.

It's backward compatible, it won't break if the `django.wsgi`file does not content the changes included in #358.