### PR TITLE
Dev/am migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Role Variables
 - `archivematica_src_reset_shareddir`: set to true to re-create the shared directory (normally at runtime using `ansible-playbook` `--extra-vars` switch)
 - `archivematica_src_reset_am_all`: set to true to re-create the MCP db and shared directory (normally at runtime using `ansible-playbook` `--extra-vars` switch). If true, it overrides the two vars above.
 - `archivematica_src_reset_ss_db`: set to true to re-create the SS database (normally at runtime using `ansible-playbook` `--extra-vars` switch)
+- `archivematica_src_pre_migration`: set to true to load the mysql seed file and run mysql_dev scripts instead of Django migrations
 
 - `archivematica_src_ss_run_syncdb`: run SS manage.py syncdb before migrate (for stable/0.7.x and previous branches that use Django 1.5.x) (default: false)
 - `archivematica_src_ss_pip_missing_deps`:  workaround to install missing SS pip dependencies in old SS branches (default: false)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Role Variables
 - `archivematica_src_reset_shareddir`: set to true to re-create the shared directory (normally at runtime using `ansible-playbook` `--extra-vars` switch)
 - `archivematica_src_reset_am_all`: set to true to re-create the MCP db and shared directory (normally at runtime using `ansible-playbook` `--extra-vars` switch). If true, it overrides the two vars above.
 - `archivematica_src_reset_ss_db`: set to true to re-create the SS database (normally at runtime using `ansible-playbook` `--extra-vars` switch)
-- `archivematica_src_pre_migration`: set to true to load the mysql seed file and run mysql_dev scripts instead of Django migrations
+- `archivematica_src_am_pre_migration`: set to true to load the mysql seed file and run mysql_dev scripts instead of Django migrations
 
 - `archivematica_src_ss_run_syncdb`: run SS manage.py syncdb before migrate (for stable/0.7.x and previous branches that use Django 1.5.x) (default: false)
 - `archivematica_src_ss_pip_missing_deps`:  workaround to install missing SS pip dependencies in old SS branches (default: false)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Role Variables
 - `archivematica_src_reset_shareddir`: set to true to re-create the shared directory (normally at runtime using `ansible-playbook` `--extra-vars` switch)
 - `archivematica_src_reset_am_all`: set to true to re-create the MCP db and shared directory (normally at runtime using `ansible-playbook` `--extra-vars` switch). If true, it overrides the two vars above.
 - `archivematica_src_reset_ss_db`: set to true to re-create the SS database (normally at runtime using `ansible-playbook` `--extra-vars` switch)
-- `archivematica_src_am_pre_migration`: set to true to load the mysql seed file and run mysql_dev scripts instead of Django migrations
+- `archivematica_src_am_pre_migration`: set to true to load the mysql seed file and run mysql_dev scripts instead of Django migrations (default: true)
 
 - `archivematica_src_ss_run_syncdb`: run SS manage.py syncdb before migrate (for stable/0.7.x and previous branches that use Django 1.5.x) (default: false)
 - `archivematica_src_ss_pip_missing_deps`:  workaround to install missing SS pip dependencies in old SS branches (default: false)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,8 +51,13 @@ archivematica_src_reset_am_all: "false"
 archivematica_src_reset_ss_db: "false"
 
 ## backwards compatibility
+
+# set to true to load the mysql seed file and run mysql_dev scripts instead of Django migrations
+archivematica_src_am_pre_migration: "true"
+
 # run SS manage.py syncdb before migrate (for stable/0.7.x and previous branches that use Django 1.5.x)
 archivematica_src_ss_run_syncdb: "false"
+
 # workaround to install missing SS pip dependencies in old SS branches
 # (some old branches of SS such as qa/0.7.2 commented out some dependencies
 #  in the requirements file and installed in the debian postinst

--- a/tasks/pipeline-dbconf.yml
+++ b/tasks/pipeline-dbconf.yml
@@ -45,7 +45,7 @@
     name: "MCP"
     state: "import"
     target: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/share/mysql"
-  when: "createdb_result|changed and archivematica_src_pre_migration|bool"
+  when: "createdb_result|changed and archivematica_src_am_pre_migration|bool"
 
 # TODO: Does this need to run as root or user archivematica ??
 - name: "Run migrations"
@@ -59,4 +59,4 @@
   args:
     chdir: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/share/"
     creates: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/share/mysql_dev.complete"
-  when: "archivematica_src_pre_migration"
+  when: "archivematica_src_am_pre_migration"

--- a/tasks/pipeline-dbconf.yml
+++ b/tasks/pipeline-dbconf.yml
@@ -40,17 +40,17 @@
     priv: "MCP.*:ALL"
     state: "present"
 
-- name: "Initialize database MCP"
+- name: "Load MySQL seed file"
   mysql_db:
     name: "MCP"
     state: "import"
     target: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/share/mysql"
-  when: "createdb_result|changed"
+  when: "createdb_result|changed and archivematica_src_pre_migration|bool"
 
 # TODO: Does this need to run as root or user archivematica ??
-- name: "Invoke django syncdb"
+- name: "Run migrations"
   django_manage:
-    command: "syncdb"
+    command: "migrate"
     app_path: "/usr/share/archivematica/dashboard/"
     settings: "settings.common"
 
@@ -59,3 +59,4 @@
   args:
     chdir: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/share/"
     creates: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/share/mysql_dev.complete"
+  when: "archivematica_src_pre_migration"

--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -52,7 +52,7 @@
   with_items:
     - src: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/share/mysql"
       dest: "/usr/share/dbconfig-common/data/archivematica-mcp-server/install/mysql"
-  when: "archivematica_src_pre_migration"
+  when: "archivematica_src_am_pre_migration"
 
 - name: "Copy archivematica-mcp-client source files"
   file: src={{ item.src }} dest={{ item.dest }} state=link

--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -41,11 +41,18 @@
       dest: "/usr/lib/archivematica/MCPServer"
     - src: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/share"
       dest: "/usr/share/archivematica/MCPServer"
-    - src: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/share/mysql"
-      dest: "/usr/share/dbconfig-common/data/archivematica-mcp-server/install/mysql"
     - src: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/init/archivematica-mcp-server.conf"
       dest: "/etc/init/archivematica-mcp-server.conf"
 
+- name: "Copy legacy archivematica-mcp-server source files"
+  file:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    state: "link"
+  with_items:
+    - src: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/share/mysql"
+      dest: "/usr/share/dbconfig-common/data/archivematica-mcp-server/install/mysql"
+  when: "archivematica_src_pre_migration"
 
 - name: "Copy archivematica-mcp-client source files"
   file: src={{ item.src }} dest={{ item.dest }} state=link


### PR DESCRIPTION
Preserve mysql seed & mysql_dev scripts behaviour in archivematica_src_am_pre_migration var.
(for now setting default to true as the AM migration code is not yet committed to qa or stable)
Note: only tested for new install, now upgrades.