### PR TITLE
Ansible 2.0 upgrades.

### DIFF
--- a/tasks/am-devtools.yml
+++ b/tasks/am-devtools.yml
@@ -24,4 +24,4 @@
   command: "make install"
   args:
     chdir: "{{ archivematica_src_dir }}/archivematica-devtools"
-  sudo: "yes"
+  become: "yes"

--- a/tasks/appraisal-tab.yml
+++ b/tasks/appraisal-tab.yml
@@ -14,4 +14,4 @@
 
 - name: "Install bower dependencies"
   bower: path="{{ archivematica_src_dir }}/archivematica/src/dashboard/src/external/appraisal-tab/"
-  sudo: no
+  become: "no"

--- a/tasks/archivematica-storage-service.yml
+++ b/tasks/archivematica-storage-service.yml
@@ -32,7 +32,7 @@
     path: "{{ archivematica_src_dir }}/archivematica-storage-service"
     mode: "o+rX"
     recurse: "yes"
-  sudo: "yes"
+  become: "yes"
   tags: am-src-ss-clone
 
 - name: "Get archivematica-storage-service latest commit hash"

--- a/tasks/pipeline-deps.yml
+++ b/tasks/pipeline-deps.yml
@@ -6,7 +6,7 @@
 ###########################################################
 
 - name: "Add multiverse repositories"
-  sudo: "yes"
+  become: "yes"
   apt_repository:
     repo: "{{ item }}"
     state: "present"
@@ -137,7 +137,7 @@
   when: clamav_download
 - name: "Copy clamav signatures to /var/lib/clamav"
   command: cp /tmp/clamav-files/{{ item }} /var/lib/clamav/
-  sudo: yes
+  become: yes
   with_items:
     - bytecode.cvd
     - daily.cvd

--- a/tasks/pipeline-osconf.yml
+++ b/tasks/pipeline-osconf.yml
@@ -88,10 +88,14 @@
     group: "archivematica"
 
 - name: "Set permissions for /var/archivematica"
-  command: "chmod -R g+s /var/archivematica/"
+  file:
+    path: "/var/archivematica/"
+    mode: "g+s"
 
 - name: "Set permissions for /var/archivematica/sharedDirectory"
-  command: "chmod -R 664 /var/archivematica/sharedDirectory"
+  file:
+    path: "/var/archivematica/sharedDirectory"
+    mode: 0664
 
 - name: "Set more permissions for /var/archivematica"
   shell: "find -L /var/archivematica/ -print0 -type d  | sudo xargs -IF -0 chmod u+rwx,g+rwxt,o-rwx F"

--- a/tasks/pipeline-osconf.yml
+++ b/tasks/pipeline-osconf.yml
@@ -46,7 +46,7 @@
     - "/usr/share/dbconfig-common/data/archivematica-mcp-server/upgrade/mysql/"
 
 
-- name: "Create archivemaitca-mcp-server log directories"
+- name: "Create archivematica-mcp-server log directories"
   file:
     dest: "{{ item }}"
     state: "directory"

--- a/tasks/tear-up.yml
+++ b/tasks/tear-up.yml
@@ -48,4 +48,4 @@
     dest: "~/archivematica-sampledata"
     update: "no"
   when: "archivematica_src_install_sample_data|bool"
-  sudo: "no"
+  become: "no"


### PR DESCRIPTION
I started using ansible 2.0 and it displays suggestions and deprecation warnings.

It also suggests we use the synchronize module instead of rsync, but I had trouble fixing it.
```
- name: "Create /var/archivematica/sharedDirectory structure"
  command: "rsync -a {{ archivematica_src_dir }}/archivematica/src/MCPServer/share/sharedDirectoryStructure/ /var/archivematica/sharedDirectory/"
```

The current playbooks all seem to work without changes in ansible 2.0.
