### PR TITLE
Several fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,8 +20,8 @@ archivematica_src_install_automationtools: "no"
 archivematica_src_environment_type: "production"
 
 # Branches,
-archivematica_src_am_version: "remotes/origin/qa/1.x"
-archivematica_src_ss_version: "remotes/origin/qa/0.x"
+archivematica_src_am_version: "qa/1.x"
+archivematica_src_ss_version: "qa/0.x"
 archivematica_src_devtools_version: "master"
 archivematica_src_automationtools_version: "master"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@
 
 
 # directory to install source code
-archivematica_src_dir: "{{ ansible_env.HOME }}"
+archivematica_src_dir: "/opt/archivematica"
 
 # Components to install
 archivematica_src_install_sample_data: "yes"

--- a/tasks/archivematica-storage-service.yml
+++ b/tasks/archivematica-storage-service.yml
@@ -21,7 +21,7 @@
     dest: "{{ archivematica_src_dir }}/archivematica-storage-service"
     version: "{{ archivematica_src_ss_version }}"
     force: "yes"
-  tags: am-src-ss-clone
+  tags: amsrc-ss-clone
 # For some reason, some dirs in the cloned source code
 # are not sometimes readable by all. Add a task to fix it
 # For some other reason this task does not always work
@@ -33,18 +33,18 @@
     mode: "o+rX"
     recurse: "yes"
   become: "yes"
-  tags: am-src-ss-clone
+  tags: amsrc-ss-clone
 
 - name: "Get archivematica-storage-service latest commit hash"
   command: "git rev-parse HEAD"
   args:
     chdir: "{{ archivematica_src_dir }}/archivematica-storage-service"
   register: "latest_commit_ss"
-  tags: am-src-ss-clone
+  tags: amsrc-ss-clone
 
 - name: "Save Archivematica Storage Service latest commit hash"
   shell: "echo {{ latest_commit_ss.stdout }} > {{ archivematica_src_dir }}/archivematica-storage-service-commit.txt"
-  tags: am-src-ss-clone
+  tags: amsrc-ss-clone
 # TODO: Make use of latest_commit_ss
 
 ###########################################################
@@ -61,7 +61,7 @@
     - "unar"
     - "uwsgi"
     - "uwsgi-plugin-python"
-  tags: am-src-ss-osdep
+  tags: amsrc-ss-osdep
 
 - name: "Install archivematica-storage-service additional package dependencies"
   apt:
@@ -75,7 +75,7 @@
     - "libz-dev"
     - "libffi-dev"
     - "libssl-dev"
-  tags: am-src-ss-osdep
+  tags: amsrc-ss-osdep
 
 ###########################################################
 #   2- python dependencies (pip packages)
@@ -88,7 +88,7 @@
     virtualenv: "/usr/share/python/archivematica-storage-service"
     extra_args: "--find-links lib"
     state: "latest"
-  tags: "am-src-ss-pydep"
+  tags: "amsrc-ss-pydep"
 
 - name: "Work around to install pip deps commented out in old SS branches"
   pip:
@@ -105,7 +105,7 @@
     - "ndg-httpsclient"
     - "pyasn1"
   when: "archivematica_src_ss_pip_missing_deps"
-  tags: "am-src-ss-pydep"
+  tags: "amsrc-ss-pydep"
 
 
 ###########################################################
@@ -119,7 +119,7 @@
   with_items:
     - "/var/archivematica/storage-service"
     - "/usr/lib/archivematica"
-  tags: am-src-ss-osconf
+  tags: amsrc-ss-osconf
 
 - name: "Set owner, group, mode of /var/archivematica recursively"
   file:
@@ -129,6 +129,8 @@
     owner: "archivematica"
     group: "archivematica"
     mode: "u=rwX,g=rwX,o=rX"
+  tags: amsrc-ss-osconf
+
 
 - name: "Create archivematica-storage-service log directories"
   file:
@@ -139,7 +141,7 @@
     mode: "g+s"
   with_items:
     - "/var/log/archivematica/storage-service"
-  tags: am-src-ss-osconf
+  tags: amsrc-ss-osconf
 
 - name: "Touch SS log files"
   file:
@@ -150,7 +152,7 @@
   with_items:
     - "storage_service.log"
     - "storage_service_debug.log"
-  tags: am-src-ss-osconf
+  tags: amsrc-ss-osconf
 
 
 ###########################################################
@@ -167,7 +169,7 @@
   with_items:
     - src: "{{ archivematica_src_dir }}/archivematica-storage-service/storage_service"
       dest: "/usr/lib/archivematica/storage-service"
-  tags: am-src-ss-code
+  tags: amsrc-ss-code
 
 - name: "Run SS django collectstatic"
   django_manage:
@@ -186,7 +188,7 @@
       SS_DB_NAME: "{{ archivematica_src_ss_env_ss_db_name }}"
       SS_DB_PASSWORD: "{{ archivematica_src_ss_env_ss_db_password }}"
       SS_DB_USER: "{{ archivematica_src_ss_env_ss_db_user }}"
-  tags: am-src-ss-code
+  tags: amsrc-ss-code
 
 
 ###########################################################
@@ -198,7 +200,7 @@
     state: "absent"
     path: "{{ archivematica_src_ss_env_ss_db_name }}"
   when: archivematica_src_reset_ss_db
-  tags: am-src-ss-db
+  tags: amsrc-ss-db
 
 - name: "Run SS django manage syncdb"
   django_manage:
@@ -218,7 +220,7 @@
       SS_DB_PASSWORD: "{{ archivematica_src_ss_env_ss_db_password }}"
       SS_DB_USER: "{{ archivematica_src_ss_env_ss_db_user }}"
   when: archivematica_src_ss_run_syncdb
-  tags: am-src-ss-db
+  tags: amsrc-ss-db
 
 - name: "Run SS django database migrations"
   django_manage:
@@ -237,7 +239,7 @@
       SS_DB_NAME: "{{ archivematica_src_ss_env_ss_db_name }}"
       SS_DB_PASSWORD: "{{ archivematica_src_ss_env_ss_db_password }}"
       SS_DB_USER: "{{ archivematica_src_ss_env_ss_db_user }}"
-  tags: am-src-ss-db
+  tags: amsrc-ss-db
 
 
 ###########################################################
@@ -248,13 +250,13 @@
   template:
     src: "etc_nginx_sites_storage.conf.j2"
     dest: "/etc/nginx/sites-available/storage.conf"
-  tags: am-src-ss-websrv
+  tags: amsrc-ss-websrv
 
 - name: "set uwsgi apps-available config file"
   template:
     src: "etc_uwsgi_apps_storage.ini.j2"
     dest: "/etc/uwsgi/apps-available/storage.ini"
-  tags: am-src-ss-websrv
+  tags: amsrc-ss-websrv
 
 - name: "Remove Nginx default server"
   file:
@@ -265,21 +267,21 @@
     - "/etc/nginx/sites-available/default.conf"
     - "/etc/nginx/sites-enabled/default"
     - "/etc/nginx/sites-enabled/default.conf"
-  tags: am-src-ss-websrv
+  tags: amsrc-ss-websrv
 
 - name: "Set up Nginx server"
   file:
     src: "/etc/nginx/sites-available/storage.conf"
     dest: "/etc/nginx/sites-enabled/storage.conf"
     state: "link"
-  tags: am-src-ss-websrv
+  tags: amsrc-ss-websrv
 
 - name: "Set up uWSGI server"
   file:
     src: "/etc/uwsgi/apps-available/storage.ini"
     dest: "/etc/uwsgi/apps-enabled/storage.ini"
     state: "link"
-  tags: am-src-ss-websrv
+  tags: amsrc-ss-websrv
 
 - name: "Enable services"
   service:
@@ -289,4 +291,4 @@
   with_items:
     - "nginx"
     - "uwsgi"
-  tags: am-src-ss-websrv
+  tags: amsrc-ss-websrv

--- a/tasks/archivematica-storage-service.yml
+++ b/tasks/archivematica-storage-service.yml
@@ -177,7 +177,7 @@
     app_path=/usr/lib/archivematica/storage-service
     virtualenv=/usr/share/python/archivematica-storage-service
   environment:
-      DJANGO_SECRET_KEY: "{{ archivematica_src_ss_django_secret_key }}"
+      DJANGO_SECRET_KEY: "{{ archivematica_src_ss_env_django_secret_key }}"
       DJANGO_SETTINGS_MODULE: "{{ archivematica_src_ss_env_django_setings_module }}"
       DJANGO_STATIC_ROOT: "{{ archivematica_src_ss_env_django_static_root }}"
       EMAIL_HOST: "{{ archivematica_src_ss_env_email_host }}"
@@ -208,7 +208,7 @@
     app_path=/usr/lib/archivematica/storage-service
     virtualenv=/usr/share/python/archivematica-storage-service
   environment:
-      DJANGO_SECRET_KEY: "{{ archivematica_src_ss_django_secret_key }}"
+      DJANGO_SECRET_KEY: "{{ archivematica_src_ss_env_django_secret_key }}"
       DJANGO_SETTINGS_MODULE: "{{ archivematica_src_ss_env_django_setings_module }}"
       DJANGO_STATIC_ROOT: "{{ archivematica_src_ss_env_django_static_root }}"
       EMAIL_HOST: "{{ archivematica_src_ss_env_email_host }}"
@@ -228,7 +228,7 @@
     app_path=/usr/lib/archivematica/storage-service
     virtualenv=/usr/share/python/archivematica-storage-service
   environment:
-      DJANGO_SECRET_KEY: "{{ archivematica_src_ss_django_secret_key }}"
+      DJANGO_SECRET_KEY: "{{ archivematica_src_ss_env_django_secret_key }}"
       DJANGO_SETTINGS_MODULE: "{{ archivematica_src_ss_env_django_setings_module }}"
       DJANGO_STATIC_ROOT: "{{ archivematica_src_ss_env_django_static_root }}"
       EMAIL_HOST: "{{ archivematica_src_ss_env_email_host }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - include: "archivematica-storage-service.yml"
   tags:
-   - "amsrc-am-ss"
+   - "amsrc-ss"
   when: archivematica_src_install_ss == "yes"
 
 #

--- a/tasks/pipeline-dbconf.yml
+++ b/tasks/pipeline-dbconf.yml
@@ -53,6 +53,9 @@
     command: "syncdb"
     app_path: "/usr/share/archivematica/dashboard/"
     settings: "settings.common"
+    pythonpath: "/usr/lib/archivematica/archivematicaCommon"
+  tags: amsrc-pipeline-dbconf-syncdb
+
 
 - name: "Call mysql_dev script"
   command: "./mysql_dev.sh MCP"

--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -38,8 +38,6 @@
     dest: "{{ item.dest }}"
     state: "link"
   with_items:
-    - src: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/etc"
-      dest: "/etc/archivematica/MCPServer"
     - src: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/lib"
       dest: "/usr/lib/archivematica/MCPServer"
     - src: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/share"
@@ -48,6 +46,11 @@
       dest: "/usr/share/dbconfig-common/data/archivematica-mcp-server/install/mysql"
     - src: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/init/archivematica-mcp-server.conf"
       dest: "/etc/init/archivematica-mcp-server.conf"
+
+- name: "template MCPServer /etc config"
+  template:
+    src: "etc_archivematica_MCPServer_serverConfig.conf.j2"
+    dest: "/etc/archivematica/MCPServer/serverConfig.conf"
 
 
 - name: "Copy archivematica-mcp-client source files"

--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -52,18 +52,23 @@
     src: "etc_archivematica_MCPServer_serverConfig.conf.j2"
     dest: "/etc/archivematica/MCPServer/serverConfig.conf"
 
-
 - name: "Copy archivematica-mcp-client source files"
   file: src={{ item.src }} dest={{ item.dest }} state=link
   with_items:
-    - src: "{{ archivematica_src_dir }}/archivematica/src/MCPClient/etc"
-      dest: "/etc/archivematica/MCPClient"
     - src: "{{ archivematica_src_dir }}/archivematica/src/MCPClient/lib/"
       dest: "/usr/lib/archivematica/MCPClient"
     - src: "{{ archivematica_src_dir }}/archivematica/src/MCPClient/init/archivematica-mcp-client.conf"
       dest: "/etc/init/archivematica-mcp-client.conf"
 
+- name: "template MCPClient /etc config"
+  template:
+    src: "etc_archivematica_MCPClient_clientConfig.conf.j2"
+    dest: "/etc/archivematica/MCPClient/clientConfig.conf"
 
+- name: "move archivematicaClientModules to /usr/lib/archivematica/MCPClient"
+  command: "mv {{ archivematica_src_dir }}/archivematica/src/MCPClient/etc/archivematicaClientModules /usr/lib/archivematica/MCPClient/"
+  args:
+    creates: "/usr/lib/archivematica/MCPClient/archivematicaClientModules"
 
 - name: "Copy archivematica-mcp-server init service"
   file:

--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -4,20 +4,23 @@
 #   4- Code install
 ###########################################################
 
-- name: "Copy archivematica-common source files"
+- name: "symlink archivematica-common source files"
   file:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     state: "link"
   with_items:
-    - src: "{{ archivematica_src_dir }}/archivematica/src/archivematicaCommon/etc"
-      dest: "/etc/archivematica/archivematicaCommon"
     - src: "{{ archivematica_src_dir }}/archivematica/src/archivematicaCommon/lib"
       dest: "/usr/lib/archivematica/archivematicaCommon"
     - src: "{{ archivematica_src_dir }}/archivematica/src/archivematicaCommon/requirements.txt"
       dest: "/usr/share/archivematica/archivematicaCommon/requirements.txt"
     - src: "{{ archivematica_src_dir }}/archivematica/src/archivematicaCommon/requirements"
       dest: "/usr/share/archivematica/archivematicaCommon/requirements"
+
+- name: "template archivematica-common /etc config"
+  template:
+    src: "etc_archivematica_archivematicaCommon_dbsettings.j2"
+    dest: "/etc/archivematica/archivematicaCommon/dbsettings"
 
 - name: "Copy archivematica-dashboard source files"
   file:

--- a/tasks/pipeline-osconf.yml
+++ b/tasks/pipeline-osconf.yml
@@ -19,7 +19,7 @@
     state: "directory"
   with_items:
     - "/usr/lib/archivematica"
-    - "/etc/archivematica"
+    - "/etc/archivematica/archivematicaCommon"
     - "/usr/share/archivematica/archivematicaCommon"
 
 
@@ -39,7 +39,7 @@
     dest: "{{ item }}"
     state: "directory"
   with_items:
-    - "/etc/archivematica"
+    - "/etc/archivematica/MCPServer"
     - "/usr/lib/archivematica"
     - "/usr/share/archivematica"
     - "/usr/share/dbconfig-common/data/archivematica-mcp-server/install/"
@@ -106,7 +106,7 @@
     dest: "{{ item }}"
     state: "directory"
   with_items:
-    - "/etc/archivematica"
+    - "/etc/archivematica/MCPClient"
     - "/usr/lib/archivematica"
 
 

--- a/templates/etc_archivematica_MCPClient_clientConfig.conf.j2
+++ b/templates/etc_archivematica_MCPClient_clientConfig.conf.j2
@@ -1,0 +1,14 @@
+[MCPClient]
+MCPArchivematicaServer = localhost:4730
+sharedDirectoryMounted = /var/archivematica/sharedDirectory/
+maxThreads = 2
+archivematicaClientModules = /usr/lib/archivematica/MCPClient/archivematicaClientModules
+clientScriptsDirectory = /usr/lib/archivematica/MCPClient/clientScripts/
+LoadSupportedCommandsSpecial = True
+#numberOfTasks 0 means detect number of cores, and use that.
+numberOfTasks = 0
+elasticsearchServer = localhost:9200
+disableElasticsearchIndexing = False
+temp_dir = /var/archivematica/sharedDirectory/tmp
+kioskMode = False
+django_settings_module = settings.common

--- a/templates/etc_archivematica_MCPServer_serverConfig.conf.j2
+++ b/templates/etc_archivematica_MCPServer_serverConfig.conf.j2
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+[MCPServer]
+MCPArchivematicaServer  =  localhost:4730
+GearmanServerWorker = localhost:4730
+watchDirectoryPath  =  /var/archivematica/sharedDirectory/watchedDirectories/
+sharedDirectory  =  /var/archivematica/sharedDirectory/
+processingDirectory  =  /var/archivematica/sharedDirectory/currentlyProcessing/
+rejectedDirectory  =  %%sharedPath%%rejected/
+watchDirectoriesPollInterval = 1
+processingXMLFile = processingMCP.xml
+waitOnAutoApprove = 0
+
+[Protocol]
+#separates Values when transported from client to server
+delimiter = <!&\delimiter/&!>
+
+#--Gearman--
+limitGearmanConnections = 10000
+limitTaskThreads = 75
+limitTaskThreadsSleep = 0.2
+reservedAsTaskProcessingThreads = 8

--- a/templates/etc_archivematica_archivematicaCommon_dbsettings.j2
+++ b/templates/etc_archivematica_archivematicaCommon_dbsettings.j2
@@ -1,0 +1,5 @@
+[client]
+user=archivematica
+password=demo
+host=localhost
+db=MCP


### PR DESCRIPTION
* Template files in /etc/archivematica ( do not symlink from source code) 
* Add pythonpath to AM db django syncdb (required by source code changes)
* Tag name fixes for consistency
* Change default source install dir to /opt/archivematica
* Fix default install AM/SS branches (remove "remotes/origin/" prefix)
* Fix var name typo (django secret key)