### PR TITLE
Add mysql client dev package to provide the mysql_config binary.

### DIFF
--- a/tasks/pipeline-deps.yml
+++ b/tasks/pipeline-deps.yml
@@ -27,6 +27,7 @@
     - "python2.7-elementtree"
     - "python-mimeparse"
     - "python-dateutil"
+    - "libmysqlclient-dev"
 
 
 - name: "Install archivematica-dashboard package dependencies"


### PR DESCRIPTION
I was running into this error when standing up an archivematica vagrant:

Downloading/unpacking mysqlclient>=1.3,<2 (from agentarchives==0.1->-r /vagrant/src/archivematica/src/archivematicaCommon/requirements/base.txt (line 7))
  Running setup.py (path:/tmp/pip_build_root/mysqlclient/setup.py) egg_info for package mysqlclient
    sh: 1: mysql_config: not found
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/tmp/pip_build_root/mysqlclient/setup.py", line 17, in <module>
        metadata, options = get_config()
      File "setup_posix.py", line 44, in get_config
        libs = mysql_config("libs_r")
      File "setup_posix.py", line 26, in mysql_config
        raise EnvironmentError("%s not found" % (mysql_config.path,))
    EnvironmentError: mysql_config not found
    Complete output from command python setup.py egg_info:
    sh: 1: mysql_config: not found

Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/tmp/pip_build_root/mysqlclient/setup.py", line 17, in <module>

    metadata, options = get_config()

  File "setup_posix.py", line 44, in get_config

    libs = mysql_config("libs_r")

  File "setup_posix.py", line 26, in mysql_config

    raise EnvironmentError("%s not found" % (mysql_config.path,))

EnvironmentError: mysql_config not found

---
I'm new to the project so I don't know if this is the canonical way to fix this sort of issue but it helped me get up and running.