### PR TITLE
Update appraisal tab installation method

### DIFF
--- a/tasks/appraisal-tab.yml
+++ b/tasks/appraisal-tab.yml
@@ -9,9 +9,6 @@
 - name: "Fix install path of node vs nodejs via symlink"
   file: src=/usr/bin/nodejs dest=/usr/bin/node state=link
 
-- name: "Install bower"
-  npm: name=bower global=yes
-
-- name: "Install bower dependencies"
-  bower: path="{{ archivematica_src_dir }}/archivematica/src/dashboard/src/external/appraisal-tab/"
+- name: "Install appraisal tab dependencies"
+  npm: path="{{ archivematica_src_dir }}/archivematica/src/dashboard/src/external/appraisal-tab/"
   become: "no"


### PR DESCRIPTION
This will need to get updated again once the appraisal tab is no longer installed via a submodule, but this fixes dependency installation for now.