### PR TITLE
Symlink client modules list instead of copy

### DIFF
--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -63,9 +63,10 @@
     backup: "yes"
 
 - name: "move archivematicaClientModules to /usr/lib/archivematica/MCPClient"
-  command: "mv {{ archivematica_src_dir }}/archivematica/src/MCPClient/etc/archivematicaClientModules /usr/lib/archivematica/MCPClient/"
-  args:
-    creates: "/usr/lib/archivematica/MCPClient/archivematicaClientModules"
+  file:
+    src: "{{ archivematica_src_dir }}/archivematica/src/MCPClient/etc/archivematicaClientModules"
+    dest: "/usr/lib/archivematica/MCPClient/archivematicaClientModules"
+    state: "link"
 
 - name: "template archivematica-mcp-server init service file"
   template:


### PR DESCRIPTION
I have the code mounted from the host to the VM, and I ran into errors where everything else updated on the VM when the code on the host changed, but not the client modules list.  Updating to symlink for consistency.