### PR TITLE
Fix typo

### DIFF
--- a/tasks/pipeline-deps.yml
+++ b/tasks/pipeline-deps.yml
@@ -130,7 +130,7 @@
 - name: "Check if MCPClient requirements file exists"
   stat:
     path: "{{ archivematica_src_dir }}/archivematica/src/MCPClient/requirements.txt"
-    register: "requirements_file"
+  register: "requirements_file"
 
 - name: "Install archivematica-mcp-client pip dependencies"
   pip:


### PR DESCRIPTION
Fix whitespace typo for register - it should be at the top level not part of stat.