### PR TITLE
dbsettings: use database instead of db

### DIFF
--- a/templates/etc_archivematica_archivematicaCommon_dbsettings.j2
+++ b/templates/etc_archivematica_archivematicaCommon_dbsettings.j2
@@ -2,4 +2,4 @@
 user=archivematica
 password=demo
 host=localhost
-db=MCP
+database=MCP


### PR DESCRIPTION
When using `read_default_file` (old `databaseInterface.py` uses it), the `db` parameter seems to be ignored. It's an alternative name for `database`. Oracle recommends to use `database` and it seems to work in our case. See https://dev.mysql.com/doc/connector-python/en/connector-python-connectargs.html.

Related: https://github.com/artefactual/archivematica/pull/439