### PR TITLE
Back-create API keys for SS users

### DIFF
--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -244,6 +244,24 @@
     SS_DB_USER: "{{ archivematica_src_ss_env_ss_db_user }}"
   tags: "amsrc-ss-db"
 
+- name: "Back create API keys for old users"
+  django_manage:
+    command: "backfill_api_keys"
+    app_path: "/usr/lib/archivematica/storage-service"
+    virtualenv: "/usr/share/python/archivematica-storage-service"
+  environment:
+    DJANGO_SECRET_KEY: "{{ archivematica_src_ss_env_django_secret_key }}"
+    DJANGO_SETTINGS_MODULE: "{{ archivematica_src_ss_env_django_setings_module }}"
+    DJANGO_STATIC_ROOT: "{{ archivematica_src_ss_env_django_static_root }}"
+    EMAIL_HOST: "{{ archivematica_src_ss_env_email_host }}"
+    EMAIL_HOST_PASSWORD: "{{ archivematica_src_ss_env_email_host_password }}"
+    EMAIL_HOST_USER: "{{ archivematica_src_ss_env_email_host_user }}"
+    EMAIL_PORT: "{{ archivematica_src_ss_env_email_port }}"
+    SS_DB_HOST: "{{ archivematica_src_ss_env_ss_db_host }}"
+    SS_DB_NAME: "{{ archivematica_src_ss_env_ss_db_name }}"
+    SS_DB_PASSWORD: "{{ archivematica_src_ss_env_ss_db_password }}"
+    SS_DB_USER: "{{ archivematica_src_ss_env_ss_db_user }}"
+  tags: "amsrc-ss-db"
 
 ###########################################################
 #   6- web server config - moved to separate files


### PR DESCRIPTION
Use Tastypie's manage.py backfill_api_keys to ensure old users have API keys on upgrade.

I haven't had a chance to test this, feel free to amend changes into this commit, @hakamine 