### PR TITLE
Add dashboard gunicorn configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,3 +81,11 @@ archivematica_src_ss_gunicorn_bind: "127.0.0.1:8001"
 ## SS nginx gunicorn related parameters
 archivematica_src_ss_nginx_proxy_read_timeout: "172800s"
 archivematica_src_ss_nginx_proxy_pass: "http://127.0.0.1:8001"
+
+# dashboard: use gunicorn instead of apache
+archivematica_src_am_dashboard_gunicorn: "false"
+# dashboard gunicorn parameters
+archivematica_src_am_dashboard_bind: "unix:/run/archivematica-dashboard.gunicorn.sock"
+
+# dashboard nginx gunicorn related parameters
+archivematica_src_am_dashboard_nginx_proxy_read_timeout: "172800s"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,13 +5,26 @@
 #
 
 
+- name: "Set fact: type of environment"
+  set_fact:
+    is_dev: "{{ archivematica_src_environment_type == 'development' }}"
+    is_prod: "{{ archivematica_src_environment_type == 'production' }}"
+  tags: "always" # inocuous to use always here
+
+- name: "Set fact: environment vars"
+  set_fact:
+    archivematica_src_am_dashboard_environment:
+      DJANGO_SETTINGS_MODULE: "{{ 'settings.local' if is_dev else 'settings.common' }}"
+  tags: "always" # inocuous to use always here
+
 - include: "tear-up.yml"
-  tags: # do not use "always" tag in role, to avoid issues when incuding other roles in a playbook
+  tags: # do not use "always" tag in role, to avoid issues when including other roles in a playbook
   - "amsrc-ss"
   - "amsrc-pipeline"
   - "amsrc-devtools"
   - "amsrc-automationtools"
   - "amsrc-appraisaltab"
+
 
 #
 # archivematica-storage-service
@@ -75,11 +88,20 @@
     - "amsrc-pipeline-dbconf"
   when: "archivematica_src_install_am|bool"
 
-- include: "pipeline-websrv.yml"
+- include: "pipeline-websrv-modwsgi.yml"
   tags:
-    - "amsrc-pipeline"
-    - "amsrc-pipeline-websrv"
-  when: "archivematica_src_install_am|bool"
+   - "amsrc-pipeline"
+   - "amsrc-pipeline-websrv"
+  when: "archivematica_src_install_am|bool and not(archivematica_src_am_dashboard_gunicorn|bool)"
+
+- include: "pipeline-websrv-gunicorn.yml"
+  tags:
+   - "amsrc-pipeline"
+   - "amsrc-pipeline-websrv"
+  when: "archivematica_src_install_am|bool and archivematica_src_am_dashboard_gunicorn|bool"
+
+
+
 
 #
 # archivematica-devtools

--- a/tasks/pipeline-websrv-gunicorn.yml
+++ b/tasks/pipeline-websrv-gunicorn.yml
@@ -1,0 +1,64 @@
+---
+
+###########################################################
+#   6- dashboard web server config - when using gunicorn with nginx
+###########################################################
+
+- name: "Stop/disable apache2"
+  service:
+    name: "apache2"
+    state: "stopped"
+    enabled: "no"
+
+- name: "Install nginx package"
+  apt:
+    pkg: "nginx"
+    state: "latest"
+  with_items:
+    - "nginx"
+
+- name: "Template dashboard nginx sites-available config file"
+  template:
+    src: "etc_nginx_sites_dashboard-gunicorn.conf.j2"
+    dest: "/etc/nginx/sites-available/dashboard.conf"
+    backup: "yes"
+
+- name: "Template gunicorn configuration file"
+  template:
+    src: "etc_archivematica_dashboard.gunicorn-config.py.j2"
+    dest: "/etc/archivematica/dashboard.gunicorn-config.py"
+    backup: "yes"
+
+- name: "set gunicorn init file"
+  template:
+    src: "etc_init_archivematica-dashboard.conf.j2"
+    dest: "/etc/init/archivematica-dashboard.conf"
+    backup: "yes"
+
+- name: "Reload Upstart configuration"
+  command: "initctl reload-configuration"
+
+- name: "Remove Nginx default server"
+  file:
+    path: "{{ item }}"
+    state: "absent"
+  with_items:
+    - "/etc/nginx/sites-available/default"
+    - "/etc/nginx/sites-available/default.conf"
+    - "/etc/nginx/sites-enabled/default"
+    - "/etc/nginx/sites-enabled/default.conf"
+
+- name: "Set up Nginx server"
+  file:
+    src: "/etc/nginx/sites-available/dashboard.conf"
+    dest: "/etc/nginx/sites-enabled/dashboard.conf"
+    state: "link"
+
+- name: "Enable services"
+  service:
+    name: "{{ item }}"
+    state: "restarted"
+    enabled: "yes"
+  with_items:
+    - "archivematica-dashboard"
+    - "nginx"

--- a/tasks/pipeline-websrv-modwsgi.yml
+++ b/tasks/pipeline-websrv-modwsgi.yml
@@ -1,7 +1,7 @@
 ---
 
 ###########################################################
-#   6- web server config
+#   6- web server config : apache2 mod_wsgi
 ###########################################################
 
 - name: "Enable mod-wsgi in Apache"

--- a/templates/etc_archivematica_dashboard.gunicorn-config.py.j2
+++ b/templates/etc_archivematica_dashboard.gunicorn-config.py.j2
@@ -1,0 +1,46 @@
+# {{ ansible_managed }}
+# Documentation: http://docs.gunicorn.org/en/stable/configure.html
+# Example: https://github.com/benoitc/gunicorn/blob/master/examples/example_config.py
+
+# http://docs.gunicorn.org/en/stable/settings.html#user
+user = "archivematica"
+
+# http://docs.gunicorn.org/en/stable/settings.html#group
+group = "archivematica"
+
+# http://docs.gunicorn.org/en/stable/settings.html#bind
+bind = "{{ archivematica_src_am_dashboard_bind }}"
+
+# http://docs.gunicorn.org/en/stable/settings.html#workers
+workers = 1
+
+# http://docs.gunicorn.org/en/stable/settings.html#timeout
+timeout = 120
+
+# http://docs.gunicorn.org/en/stable/settings.html#reload
+reload = {{ 'True' if is_dev else 'False' }}
+
+# http://docs.gunicorn.org/en/stable/settings.html#chdir
+chdir = "/usr/share/archivematica/dashboard"
+
+# http://docs.gunicorn.org/en/stable/settings.html#raw-env
+raw_env = [
+{% for key, value in archivematica_src_am_dashboard_environment.iteritems() %}
+    "{{ key }}={{ value }}",
+{% endfor %}
+]
+
+# http://docs.gunicorn.org/en/stable/settings.html#accesslog
+accesslog = "/var/log/archivematica/dashboard/gunicorn.access_log"
+
+# http://docs.gunicorn.org/en/stable/settings.html#errorlog
+errorlog = "/var/log/archivematica/dashboard/gunicorn.error_log"
+
+# http://docs.gunicorn.org/en/stable/settings.html#loglevel
+loglevel = "{{ 'debug' if is_dev else 'info' }}"
+
+# http://docs.gunicorn.org/en/stable/settings.html#proc-name
+proc_name = "archivematica-dashboard"
+
+# http://docs.gunicorn.org/en/stable/settings.html#pythonpath
+pythonpath = "/usr/share/archivematica/dashboard,/usr/lib/archivematica/archivematicaCommon"

--- a/templates/etc_init_archivematica-dashboard.conf.j2
+++ b/templates/etc_init_archivematica-dashboard.conf.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+description "Archivematica Storage Service"
+author "Artefactual Systems"
+
+start on (runlevel [2345] and filesystem)
+stop on runlevel [016]
+
+exec /usr/local/bin/gunicorn --config /etc/archivematica/dashboard.gunicorn-config.py wsgi:application

--- a/templates/etc_nginx_sites_dashboard-gunicorn.conf.j2
+++ b/templates/etc_nginx_sites_dashboard-gunicorn.conf.j2
@@ -1,0 +1,36 @@
+# {{ ansible_managed }}
+
+upstream archivematica_dashboard_backend {
+
+    server {{ archivematica_src_am_dashboard_bind }};
+
+}
+
+server {
+
+  listen 80;
+
+  # Adjust to taste
+  client_max_body_size 256M;
+
+  server_name _;
+
+  location / {
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_redirect off;
+    proxy_buffering off;
+    proxy_read_timeout {{ archivematica_src_am_dashboard_nginx_proxy_read_timeout }};
+    proxy_pass http://archivematica_dashboard_backend;
+  }
+
+  location /media {
+    alias /usr/share/archivematica/dashboard/media;
+  }
+
+  error_page 500 502 503 504 /500.html;
+  location = /500.html {
+    alias /usr/share/archivematica/dashboard/templates;
+  }
+
+}


### PR DESCRIPTION
Add variable archivematica_src_am_dashboard_gunicorn. If true,
dashboard will be configured to use gunicorn/nginx instead of
apache2/mod_wsgi. For now, default value is false.