### PR TITLE
Fix SS DB permissions after resetting

### DIFF
--- a/tasks/ss-db.yml
+++ b/tasks/ss-db.yml
@@ -27,6 +27,14 @@
     virtualenv: "/usr/share/python/archivematica-storage-service"
   environment: "{{ archivematica_src_ss_environment }}"
 
+- name: "Fix DB permissions after reset"
+  file:
+    dest: "{{ archivematica_src_ss_env_ss_db_name }}"
+    owner: "archivematica"
+    group: "archivematica"
+    mode: "u=rwX,g=rwX,o=rX"
+  when: "archivematica_src_reset_ss_db|bool"
+
 - name: "Back create API keys for old users"
   django_manage:
     command: "backfill_api_keys"


### PR DESCRIPTION
Set the SS DB permissions after deleting & recreating it. Otherwise, gets a cannot write to read only DB error.