### PR TITLE
Fix tags for amsrc-pipeline-dbconf-syncdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Note that if something is disabled with the [role variables](#role-variables), i
     - `amsrc-pipeline-osconf`: Configure operating system
     - `amsrc-pipeline-instcode`: Install source code
     - `amsrc-pipeline-dbconf`: Configure database
+        - `amsrc-pipeline-dbconf-syncdb`: Only run Django's syncdb/migrations
     - `amsrc-pipeline-websrv`: Configure webserver
 - `amsrc-devtools`: Archivematica devtools install
 - `amsrc-automationtools`: Automation tools install

--- a/tasks/pipeline-dbconf.yml
+++ b/tasks/pipeline-dbconf.yml
@@ -50,10 +50,12 @@
   stat:
     path: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/share/mysql_dev.sh"
   register: "mysql_dev_sh_check"
+  tags: "amsrc-pipeline-dbconf-syncdb"
 
 - name: "Set migrations path"
   set_fact:
     archivematica_src_am_pre_migration: "{{ mysql_dev_sh_check.stat.exists }}"
+  tags: "amsrc-pipeline-dbconf-syncdb"
 
 # mysql-dev migrations
 - name: "Load MySQL seed file"


### PR DESCRIPTION
Fix tags so migrations work when only running amsrc-pipeline-dbconf-syncdb