### PR TITLE
SS: Install testing dependencies in dev

### DIFF
--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -88,16 +88,21 @@
 - stat:
     path: "{{ archivematica_src_dir }}/archivematica-storage-service/lib"
   register: "ss_lib_dir_check"
+  tags: "amsrc-ss-pydep"
+
 - set_fact:
     ss_pip_install_extra_args: ""
+  tags: "amsrc-ss-pydep"
+
 - set_fact:
     ss_pip_install_extra_args: "--find-links lib"
   when: "ss_lib_dir_check.stat.isdir is defined and ss_lib_dir_check.stat.isdir"
+  tags: "amsrc-ss-pydep"
 
 - name: "Create virtualenv for archivematica-storage-service, pip install requirements"
   pip:
     chdir: "{{ archivematica_src_dir }}/archivematica-storage-service"
-    requirements: "requirements.txt"
+    requirements: "{{ 'requirements/test.txt' if is_dev else 'requirements.txt'}}"
     virtualenv: "/usr/share/python/archivematica-storage-service"
     extra_args: "{{ ss_pip_install_extra_args }}"
     state: "latest"


### PR DESCRIPTION
If is_dev is set, install from testing deps not just base.

I'd like to do this in AM as well, but I'd like to standardize the requirements files on `base.txt` / `test.txt` / `dev.txt` as done in artefactual/archivematica#490 first, so the ansible role is simpler.