### PR TITLE
Install gettext in dashboard and SS envs

### DIFF
--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -78,6 +78,7 @@
     - "libz-dev"
     - "libffi-dev"
     - "libssl-dev"
+    - "gettext"
   tags: "amsrc-ss-osdep"
 
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,6 +11,7 @@ archivematica_src_am_dashboard_pkgdeps_qa_1_x:
   - "apache2-mpm-prefork"
   - "libapache2-mod-wsgi"
   - "python-pip"
+  - "gettext"
 
 archivematica_src_am_mcpserver_pkgdeps_qa_1_x:
   - "dbconfig-common"


### PR DESCRIPTION
gettext is used by `manage.py makemessages` and `mange.py compilemessages`