### PR TITLE
Use working versions of python-pip and python-virtualenv

### DIFF
--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -89,6 +89,38 @@
   when: "ss_lib_dir_check.stat.isdir is defined and ss_lib_dir_check.stat.isdir"
   tags: "amsrc-ss-pydep"
 
+- name: "Create virtualenv for archivematica-storage-service"
+  pip:
+    name: "pip"
+    chdir: "{{ archivematica_src_dir }}/archivematica-storage-service"
+    virtualenv: "/usr/share/python/archivematica-storage-service"
+    state: "latest"
+  tags: "amsrc-ss-pydep"
+
+- name: "Update pip in virtualenv for archivematica-storage-service"
+  pip:
+    name: "pip"
+    chdir: "{{ archivematica_src_dir }}/archivematica-storage-service"
+    virtualenv: "/usr/share/python/archivematica-storage-service"
+    state: "latest"
+  tags: "amsrc-ss-pydep"
+
+- name: "Update setuptools in virtualenv for archivematica-storage-service"
+  pip:
+    name: "setuptools"
+    chdir: "{{ archivematica_src_dir }}/archivematica-storage-service"
+    virtualenv: "/usr/share/python/archivematica-storage-service"
+    state: "absent"
+  tags: "amsrc-ss-pydep"
+
+- name: "Update setuptools in virtualenv for archivematica-storage-service"
+  pip:
+    name: "setuptools"
+    chdir: "{{ archivematica_src_dir }}/archivematica-storage-service"
+    virtualenv: "/usr/share/python/archivematica-storage-service"
+    state: "latest"
+  tags: "amsrc-ss-pydep"
+
 - name: "Create virtualenv for archivematica-storage-service, pip install requirements"
   pip:
     chdir: "{{ archivematica_src_dir }}/archivematica-storage-service"

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -61,7 +61,6 @@
     pkg: "{{ item }}"
     state: "latest"
   with_items:
-    - "python-virtualenv"
     - "python-dev"
     - "libxml2-dev"
     - "libxslt1-dev"

--- a/tasks/tear-up.yml
+++ b/tasks/tear-up.yml
@@ -12,6 +12,21 @@
     - "python-pycurl"
     - "git"
 
+- name: "Downgrade python-pip and python-virtualenv"
+  apt:
+    pkg: "{{ item }}"
+  with_items:
+    - "python-pip=1.5.4-1"
+    - "python-virtualenv=1.11.4-1"
+    - "git"
+
+- name: "Set python-pip and python-virtualenv on hold"
+  dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  with_items:
+    - "python-pip"
+    - "python-virtualenv"
 # apt repository config for external dependencies 
 #   - if ppa: add the repo
 #   - if not ppa: add the key and the repo

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,13 +4,11 @@
 # # package dependencies (qa/1.x)
 archivematica_src_am_common_pkgdeps_qa_1_x:
   - "python"
-  - "python-pip"
   - "libmysqlclient-dev"
 
 archivematica_src_am_dashboard_pkgdeps_qa_1_x:
   - "apache2-mpm-prefork"
   - "libapache2-mod-wsgi"
-  - "python-pip"
   - "gettext"
 
 archivematica_src_am_mcpserver_pkgdeps_qa_1_x:
@@ -56,7 +54,6 @@ archivematica_src_am_mcpclient_pkgdeps_qa_1_x:
 
 archivematica_src_am_common_pkgdeps_v1_4:
   - "python"
-  - "python-pip"
   - "libmysqlclient-dev"
   - "python2.7-elementtree"
   - "python-mimeparse"
@@ -65,7 +62,6 @@ archivematica_src_am_common_pkgdeps_v1_4:
 archivematica_src_am_dashboard_pkgdeps_v1_4:
   - "apache2-mpm-prefork"
   - "libapache2-mod-wsgi"
-  - "python-pip"
   - "python-gearman"
   - "python-simplejson"
   - "python-dev"


### PR DESCRIPTION
Due to an ubuntu bug ( https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1658844 ) current ones are broken, so we stick with the previous version for now.