### PR TITLE
workaround to fix pip problem

### DIFF
--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -90,6 +90,30 @@
   when: "ss_lib_dir_check.stat.isdir is defined and ss_lib_dir_check.stat.isdir"
   tags: "amsrc-ss-pydep"
 
+- name: "Create virtualenv for archivematica-storage-service"
+  pip:
+    name: "pip"
+    chdir: "{{ archivematica_src_dir }}/archivematica-storage-service"
+    virtualenv: "/usr/share/python/archivematica-storage-service"
+    state: "latest"
+  tags: "amsrc-ss-pydep"
+
+- name: "Update setuptools in virtualenv for archivematica-storage-service"
+  pip:
+    name: "setuptools"
+    chdir: "{{ archivematica_src_dir }}/archivematica-storage-service"
+    virtualenv: "/usr/share/python/archivematica-storage-service"
+    state: "absent"
+  tags: "amsrc-ss-pydep"
+
+- name: "Update setuptools in virtualenv for archivematica-storage-service"
+  pip:
+    name: "setuptools"
+    chdir: "{{ archivematica_src_dir }}/archivematica-storage-service"
+    virtualenv: "/usr/share/python/archivematica-storage-service"
+    state: "latest"
+  tags: "amsrc-ss-pydep"
+
 - name: "Create virtualenv for archivematica-storage-service, pip install requirements"
   pip:
     chdir: "{{ archivematica_src_dir }}/archivematica-storage-service"

--- a/tasks/tear-up.yml
+++ b/tasks/tear-up.yml
@@ -4,10 +4,10 @@
   apt:
     update_cache: "yes"
 
-- name: "remove broken python-pip (for ubuntu 14.04)"
+- name: "Remove broken python-pip (for ubuntu 14.04)"
   apt:
     pkg: "{{ item }}"
-    state: absent
+    state: "absent"
   with_items:
     - "python-pip"
     

--- a/tasks/tear-up.yml
+++ b/tasks/tear-up.yml
@@ -4,13 +4,27 @@
   apt:
     update_cache: "yes"
 
-- name: "Install necessary packages"
+- name: "remove broken python-pip (for ubuntu 14.04)"
+  apt:
+    pkg: "{{ item }}"
+    state: absent
+  with_items:
+    - "python-pip"
+    
+- name: "Install necessary prerequisite packages"
   apt:
     pkg: "{{ item }}"
     state: "latest"
   with_items:
     - "python-pycurl"
     - "git"
+    - "python-setuptools"
+    - "python-virtualenv"
+
+- name: "install pip with easy_install"
+  easy_install:
+    name: pip
+    state: latest
 
 # apt repository config for external dependencies 
 #   - if ppa: add the repo


### PR DESCRIPTION
This change is for Ubuntu 14.04 installs (currently only os supported by this role).  This PR is an alternative to #102 which does not completely solve the issue.

It is required due to a recent bug https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1658844
in the python-pip package for 14.04.

This change removes the python-pip package and installs pip with easy_install, in order to get a newer version.  It also upgrades the version of pip in the storage service virtualenv.

This is workaround.  Ideally the ubuntu package will be fixed, and this will no longer be necessary, although it should do no harm.  The longer term solution will be to make this role create a separate virtualenv for each Archivematica package (mcp-server, mcp-client, dashboard) and not just for the storage service.  