### PR TITLE
Use conf vars for mysql and es configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,10 +54,18 @@ archivematica_src_ss_env_ss_db_name: "/var/archivematica/storage-service/storage
 archivematica_src_ss_env_ss_db_password: ""
 archivematica_src_ss_env_ss_db_user: ""
 
+
+# database settings
+archivematica_src_am_database_name: "MCP"
+archivematica_src_am_database_user: "archivematica"
+archivematica_src_am_database_host: "localhost"
+archivematica_src_am_database_password: "demo"
 # reset the MCP database (CAUTION: if true, will lose existing MCP database data)
 archivematica_src_reset_mcpdb: "false"
 # delete the existing shared directory
 archivematica_src_reset_shareddir: "false"
+#ES Host
+archivematica_src_am_es_host: "localhost:9200"
 # Delete ElasticSearch indexes
 archivematica_src_reset_es: "false"
 # reset the AM database (MCP), delete AM shared dir and reset ElasticSearch indexes (if true, it overrides the three reset vars above)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,10 +64,16 @@ archivematica_src_am_database_password: "demo"
 archivematica_src_reset_mcpdb: "false"
 # delete the existing shared directory
 archivematica_src_reset_shareddir: "false"
-#ES Host
-archivematica_src_am_es_host: "localhost:9200"
+
+#Gearman server
+archivematica_src_gearman_server: "localhost:4730"
+
+#ElasticSearch server configuration
+archivematica_src_elasticsearch_server: "localhost:9200"
+archivematica_src_elasticsearch_timeout: 10
 # Delete ElasticSearch indexes
 archivematica_src_reset_es: "false"
+
 # reset the AM database (MCP), delete AM shared dir and reset ElasticSearch indexes (if true, it overrides the three reset vars above)
 archivematica_src_reset_am_all: "false"
 

--- a/tasks/pipeline-dbconf.yml
+++ b/tasks/pipeline-dbconf.yml
@@ -36,6 +36,7 @@
     encoding: "utf8"
     collation: "utf8_unicode_ci"
   register: "createdb_result"
+  when: 'archivematica_src_am_database_host == "localhost"'
 
 # TODO: need to change the mysql password for user archivematica
 
@@ -45,6 +46,7 @@
     password: "demo"
     priv: "MCP.*:ALL"
     state: "present"
+  when: 'archivematica_src_am_database_host == "localhost"'
 
 - name: "Check if mysql_dev exists"
   stat:

--- a/templates/etc_archivematica_MCPClient_clientConfig.conf.j2
+++ b/templates/etc_archivematica_MCPClient_clientConfig.conf.j2
@@ -7,7 +7,7 @@ clientScriptsDirectory = /usr/lib/archivematica/MCPClient/clientScripts/
 LoadSupportedCommandsSpecial = True
 #numberOfTasks 0 means detect number of cores, and use that.
 numberOfTasks = 0
-elasticsearchServer = localhost:9200
+elasticsearchServer = {{ archivematica_src_am_es_host }}
 disableElasticsearchIndexing = False
 temp_dir = {{ archivematica_src_shareddir }}/tmp
 kioskMode = False

--- a/templates/etc_archivematica_MCPClient_clientConfig.conf.j2
+++ b/templates/etc_archivematica_MCPClient_clientConfig.conf.j2
@@ -1,5 +1,5 @@
 [MCPClient]
-MCPArchivematicaServer = localhost:4730
+MCPArchivematicaServer = {{ archivematica_src_gearman_server }}
 sharedDirectoryMounted = {{ archivematica_src_shareddir }}/
 maxThreads = 2
 archivematicaClientModules = {{ archivematica_src_clientmodules }}
@@ -7,7 +7,8 @@ clientScriptsDirectory = /usr/lib/archivematica/MCPClient/clientScripts/
 LoadSupportedCommandsSpecial = True
 #numberOfTasks 0 means detect number of cores, and use that.
 numberOfTasks = 0
-elasticsearchServer = {{ archivematica_src_am_es_host }}
+elasticsearchServer = {{ archivematica_src_elasticsearch_server }}
+elasticsearchTimeout = {{ archivematica_src_elasticsearch_timeout }}
 disableElasticsearchIndexing = False
 temp_dir = {{ archivematica_src_shareddir }}/tmp
 kioskMode = False

--- a/templates/etc_archivematica_archivematicaCommon_dbsettings.j2
+++ b/templates/etc_archivematica_archivematicaCommon_dbsettings.j2
@@ -1,6 +1,6 @@
 [client]
-user=archivematica
-password=demo
-host=localhost
-database=MCP
+user={{ archivematica_src_am_database_user }}
+password={{ archivematica_src_am_database_password }}
+host={{ archivematica_src_am_database_host }}
+database={{ archivematica_src_am_database_name }}
 max_overflow=40

--- a/templates/etc_init_archivematica-mcp-server.conf.j2
+++ b/templates/etc_init_archivematica-mcp-server.conf.j2
@@ -28,6 +28,7 @@ pre-start script
     done
     gearadmin --getpid || exit 1
 
+    {% if archivematica_src_am_database_host == "localhost" %}
     # Wait for mysql to start - timeout eventually
     for i in $(seq 1 10)
     do
@@ -35,6 +36,7 @@ pre-start script
         sleep 3
     done
     mysqladmin ping || exit 1
+    {% endif %}
 
     exit 0
 


### PR DESCRIPTION
Add mysql conf vars, and don't create database when mysql host is different from localhost

This allows use of hosted mysql/es instances.