### PR TITLE
Configures and starts rng-tools (for GPG encryption key generation)

### DIFF
--- a/tasks/ss-osdeps.yml
+++ b/tasks/ss-osdeps.yml
@@ -74,3 +74,28 @@
     - storage_service is defined 
     - storage_service.osdeps_packages_3 is defined
     - storage_service.osdeps_packages_3
+
+- name: "Configure rng-tools"
+  lineinfile:
+    dest: "/etc/default/rng-tools"
+    line: "HRNGDEVICE=/dev/urandom"
+    insertafter: "^#HRNGDEVICE"
+    state: "present"
+  tags: "rng-tools"
+  become: "yes"
+  when:
+    - osdeps
+    - storage_service is defined
+    - storage_service.osdeps_packages is defined
+    - storage_service.osdeps_packages
+    - ansible_distribution == "Ubuntu"
+
+- name: "Start rng-tools"
+  command: "/etc/init.d/rng-tools start"
+  tags: "rng-tools"
+  when:
+    - osdeps
+    - storage_service is defined
+    - storage_service.osdeps_packages is defined
+    - storage_service.osdeps_packages
+    - ansible_distribution == "Ubuntu"


### PR DESCRIPTION
This configures and starts the rng-tools service, which is needed in order for efficient GPG key generation. If rng-tools is not running, key generation is intolerably slow.

The gnupg and rng-tools dependencies are declared in SS's osdeps/Ubuntu-14.json file. See
https://github.com/artefactual/archivematica-storage-service/pull/198/files.