### PR TITLE
Can install .deb files from MCPClient.osdeps_debfiles

### DIFF
--- a/tasks/pipeline-osdeps-MCPClient.yml
+++ b/tasks/pipeline-osdeps-MCPClient.yml
@@ -27,6 +27,13 @@
       when:
         - "MCPClient.osdeps_packages"
 
+    - name: "Install MCPClient ext. package deb file deps."
+      apt:
+        deb: "{{ item }}"
+      with_items: "{{ MCPClient.osdeps_debfiles }}"
+      when:
+        - "MCPClient.osdeps_debfiles"
+
   when:
     - ansible_distribution == "Ubuntu"
 

--- a/tasks/pipeline-osdeps-MCPClient.yml
+++ b/tasks/pipeline-osdeps-MCPClient.yml
@@ -32,7 +32,7 @@
         deb: "{{ item }}"
       with_items: "{{ MCPClient.osdeps_debfiles }}"
       when:
-        - "MCPClient.osdeps_debfiles"
+        - "MCPClient.osdeps_debfiles is defined and MCPClient.osdeps_debfiles"
 
   when:
     - ansible_distribution == "Ubuntu"


### PR DESCRIPTION
Is able to process a key "osdeps_debfiles" in MCPClient/osdeps/Ubuntu-14.json
that valuates to an array of .deb URLs. Perhaps this should be
generalized to other pipeline-osdeps-* files.

Needed by https://github.com/artefactual/archivematica/blob/dev/issue-9478-preforma-qa-1-x/src/MCPClient/osdeps/Ubuntu-14.json