### PR TITLE
Set required vars in dashboard env

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,9 @@ archivematica_src_am_version: "qa/1.x"
 archivematica_src_ss_version: "qa/0.x"
 archivematica_src_devtools_version: "master"
 
+archivematica_src_am_env_django_secret_key: "CHANGE_ME_WITH_A_SECRET_KEY"
+archivematica_src_am_env_django_allowed_hosts: "*"
+
 # SS django environment variables
 # DJANGO_SECRET_KEY shall be changed for every install
 #     (override the value in the playboook, do not change here)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,8 @@
   set_fact:
     archivematica_src_am_dashboard_environment:
       DJANGO_SETTINGS_MODULE: "{{ 'settings.local' if is_dev else 'settings.common' }}"
+      ARCHIVEMATICA_DASHBOARD_DASHBOARD_DJANGO_ALLOWED_HOSTS: "{{ archivematica_src_am_env_django_allowed_hosts }}"
+      ARCHIVEMATICA_DASHBOARD_DASHBOARD_DJANGO_SECRET_KEY: "{{ archivematica_src_am_env_django_secret_key }}"
     archivematica_src_ss_environment:
       DJANGO_SECRET_KEY: "{{ archivematica_src_ss_env_django_secret_key }}"
       DJANGO_SETTINGS_MODULE: "{{ archivematica_src_ss_env_django_setings_module }}"

--- a/tasks/pipeline-dbconf.yml
+++ b/tasks/pipeline-dbconf.yml
@@ -91,6 +91,7 @@
     app_path: "/usr/share/archivematica/dashboard/"
     settings: "settings.common"
     pythonpath: "/usr/lib/archivematica/archivematicaCommon"
+  environment: "{{ archivematica_src_am_dashboard_environment }}"
   tags: "amsrc-pipeline-dbconf-syncdb"
   when: 
     - "not archivematica_src_am_pre_migration|bool"
@@ -103,6 +104,7 @@
     settings: "settings.common"
     pythonpath: "/usr/lib/archivematica/archivematicaCommon"
     virtualenv: "/usr/share/python/archivematica-dashboard"
+  environment: "{{ archivematica_src_am_dashboard_environment }}"
   tags: "amsrc-pipeline-dbconf-syncdb"
   when: 
     - "not archivematica_src_am_pre_migration|bool"

--- a/templates/etc_init_archivematica-mcp-client.conf.j2
+++ b/templates/etc_init_archivematica-mcp-client.conf.j2
@@ -15,6 +15,7 @@ env PATH="/usr/share/python/archivematica-mcp-client/bin:/usr/local/sbin:/usr/lo
 env PYTHONPATH=/usr/lib/archivematica/archivematicaCommon/:/usr/share/archivematica/dashboard/
 {% else %}
 env PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
+env DJANGO_SETTINGS_MODULE=settings.common
 {% endif %}
 
 setuid archivematica

--- a/templates/etc_init_archivematica-mcp-client.conf.j2
+++ b/templates/etc_init_archivematica-mcp-client.conf.j2
@@ -12,11 +12,11 @@ env LOCATION="{{ mcp_client_python_path }} /usr/lib/archivematica/MCPClient/arch
 {% if archivematica_src_am_multi_venvs|bool %}
 # fix PATH so that python is the MCPClient virtualenv is used
 env PATH="/usr/share/python/archivematica-mcp-client/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
-env PYTHONPATH=/usr/lib/archivematica/archivematicaCommon/:/usr/share/archivematica/dashboard/
+env PYTHONPATH=/usr/lib/archivematica/MCPClient/:/usr/lib/archivematica/archivematicaCommon/:/usr/share/archivematica/dashboard/
 {% else %}
 env PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
-env DJANGO_SETTINGS_MODULE=settings.common
 {% endif %}
+env DJANGO_SETTINGS_MODULE=settings.common
 
 setuid archivematica
 setgid archivematica

--- a/templates/etc_init_archivematica-mcp-server.conf.j2
+++ b/templates/etc_init_archivematica-mcp-server.conf.j2
@@ -10,6 +10,7 @@ env CONF=/etc/archivematica/MCPServer
 env LOCATION="{{ mcp_server_python_path }} /usr/lib/archivematica/MCPServer/archivematicaMCP.py"
 {% if archivematica_src_am_multi_venvs|bool %}
 env PYTHONPATH=/usr/lib/archivematica/archivematicaCommon/:/usr/share/archivematica/dashboard/
+env DJANGO_SETTINGS_MODULE=settings.common
 {% endif %}
 
 setuid archivematica


### PR DESCRIPTION
This supports deploying Archivematica with environment variable configuration: https://github.com/artefactual/archivematica/pull/670 - it's still WIP as that work isnt' fully tested yet and there may be further fixes required here.

It sets up some env vars that are required by Archivematica, and allows them to be configured from ansible.