### PR TITLE
Use python3 in virtualenv

### DIFF
--- a/tasks/acceptance-tests.yml
+++ b/tasks/acceptance-tests.yml
@@ -22,7 +22,7 @@
     chdir: "{{ archivematica_src_dir }}/archivematica-acceptance-tests"
     requirements: "requirements.txt"
     virtualenv: "/usr/share/python/archivematica-acceptance-tests"
-    virtualenv_python: "python3.4"
+    virtualenv_python: "python3"
     state: latest
 
 #


### PR DESCRIPTION
Before, python3.4 was used which is not available in Ubuntu Xenial.