### PR TITLE
Systemd: add new envs

### DIFF
--- a/templates/etc/sysconfig/archivematica-mcp-client.j2
+++ b/templates/etc/sysconfig/archivematica-mcp-client.j2
@@ -1,4 +1,5 @@
 # this file is managed by ansible
 
+DJANGO_SETTINGS_MODULE=settings.common
 PATH=/usr/share/python/archivematica-mcp-client/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
-PYTHONPATH=/usr/lib/archivematica/archivematicaCommon/:/usr/share/archivematica/dashboard/
+PYTHONPATH=/usr/lib/archivematica/MCPClient/:/usr/lib/archivematica/archivematicaCommon/:/usr/share/archivematica/dashboard/

--- a/templates/etc/sysconfig/archivematica-mcp-server.j2
+++ b/templates/etc/sysconfig/archivematica-mcp-server.j2
@@ -1,3 +1,4 @@
 # this file is managed by ansible
 
+DJANGO_SETTINGS_MODULE=settings.common
 PYTHONPATH=/usr/lib/archivematica/archivematicaCommon/:/usr/share/archivematica/dashboard/


### PR DESCRIPTION
This PR complements #115. It adds the new required environment strings to systemd env files.