### PR TITLE
Don't copy across MCP Server shared dir structure

### DIFF
--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -41,8 +41,6 @@
   with_items:
     - src: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/lib"
       dest: "/usr/lib/archivematica/MCPServer"
-    - src: "{{ archivematica_src_dir }}/archivematica/src/MCPServer/share"
-      dest: "/usr/share/archivematica/MCPServer"
 
 - name: "template MCPServer /etc config"
   template:

--- a/tasks/pipeline-osconf.yml
+++ b/tasks/pipeline-osconf.yml
@@ -88,22 +88,6 @@
     state: "link"
   when: create_shareddir and archivematica_src_shareddir != "/var/archivematica/sharedDirectory"
 
-# copy of shared dir structure should be executed also for upgrades (to reflect changes) 
-# Note: --chown option requires rsync version >=3.1.0
-#       centos 7 does not currently support it
-- name: "Copy shared directory structure (non RH)"
-  command: "rsync -a --chown=archivematica:archivematica {{ archivematica_src_dir }}/archivematica/src/MCPServer/share/sharedDirectoryStructure/ {{ archivematica_src_shareddir }}/"
-  when: not (ansible_os_family == "RedHat")
-
-- name: "Copy shared directory structure (RH)"
-  command: "rsync -rl {{ archivematica_src_dir }}/archivematica/src/MCPServer/share/sharedDirectoryStructure/ {{ archivematica_src_shareddir }}/"
-  when: ansible_os_family == "RedHat"
-- name: "Fix shared directory structure ownership (RH)"
-  shell: "ls -1 | xargs chown -R archivematica:archivematica"
-  args:
-    chdir: "{{ archivematica_src_shareddir }}"
-  when: ansible_os_family == "RedHat"
-
 - name: "Create subdirectories for archivematica-mcp-client source files"
   file:
     dest: "{{ item }}"


### PR DESCRIPTION
To match changes in https://github.com/artefactual/archivematica/pull/681 

MCPServer now sets up its own shared directory structure when it runs, so the directory structure that used to be copied across is being removed from the source tree in that PR. This removes the commands that used to copy it across.