### PR TITLE
Download archivematica-sampledata in the background

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ archivematica_src_install_am: "yes"
 archivematica_src_install_ss: "yes"
 archivematica_src_install_devtools: "no"
 archivematica_src_install_appraisaltab: "no"
+archivematica_src_install_sample_data_timeout: "3600"
 
 # Define the type of environment: "production" or "development". The latter
 # will deploy some extra stuff to make the development workflow easier.

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -78,4 +78,7 @@
     update: "no"
     depth: 1
   when: "archivematica_src_install_sample_data|bool"
+  async: "{{ archivematica_src_install_sample_data_timeout }}"
+  poll: 0
+  register: "sampledata_clone"
   become: "no"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -191,3 +191,16 @@
   tags:
     - "amsrc-acceptancetests"
   when: "archivematica_src_install_acceptance_tests|bool"
+
+#
+# Wait for git to finish sampledata clone
+#
+- name: "Wait for sampledata download completion"
+  async_status:
+    jid: "{{ sampledata_clone.ansible_job_id }}"
+  when: "archivematica_src_install_sample_data|bool"
+  register: "sampledata_clone_result"
+  until: "sampledata_clone_result.finished"
+  delay: 60
+  retries: "{{ ( archivematica_src_install_sample_data_timeout / 60 )|int|abs }}"
+  become: "no"


### PR DESCRIPTION
The current archivematica-sampledata repo size is more than 1 gb. Instead of waiting for it to be cloned, run git in background and continue the install process.

If the ansible process finishes, the git clone task will continue running for one hour (3600 s)