### PR TITLE
Install Node and build front-end assets

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,4 +14,7 @@ galaxy_info:
     - trusty
     - xenial
 
-dependencies: []
+dependencies:
+- role: geerlingguy.nodejs
+  version: 4.1.1
+  nodejs_version: 8.x

--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -79,6 +79,21 @@
 
 
 #
+# front-end
+#
+
+- name: "Install front-end dependencies"
+  npm:
+    path: "{{ item }}"
+    state: "present"
+  with_items:
+    - "{{ archivematica_src_dir }}/archivematica/src/dashboard/frontend/appraisal-tab"
+    - "{{ archivematica_src_dir }}/archivematica/src/dashboard/frontend/transfer-browser"
+  when:
+    - "ansible_env.USER != 'vagrant'"
+
+
+#
 # collectstatic
 #
 
@@ -89,4 +104,3 @@
     pythonpath: "{{ archivematica_src_am_common_app }}"
     virtualenv: "{{ archivematica_src_am_dashboard_virtualenv }}"
   environment: "{{ archivematica_src_am_dashboard_environment }}"
-  tags: "amsrc-ss-websrv"


### PR DESCRIPTION
This is according to https://github.com/artefactual/archivematica/pull/678 which brings appraisal-tab and transfer-browser to the Dashboard tree instead of vendoring.

In this PR we want to (1) build the assets, (2) leave the building tools installed so the developer can use them.

If you're wondering about the impact of using `npm install`, I've tried locally and each project takes about 30 seconds to download all the dependencies and build them. I've also tried with yarn, it's a bit faster but with npm@5 the different is not too big.