### PR TITLE
Typo in archivematica-mcp-client.service.j2

### DIFF
--- a/templates/etc/systemd/system/archivematica-mcp-client.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-client.service.j2
@@ -9,7 +9,7 @@ Type=simple
 User=archivematica
 Group=archivematica
 EnvironmentFile=-{{ systemd_environment_path }}/archivematica-mcp-client
-ExecStart={{ archivematica_src_am_mcpserver_virtualenv }}/bin/python {{ archivematica_src_am_mcpclient_app }}/archivematicaClient.py
+ExecStart={{ archivematica_src_am_mcpclient_virtualenv }}/bin/python {{ archivematica_src_am_mcpclient_app }}/archivematicaClient.py
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The mcp-client systemd init script is using the mcp-server's python. 