### PR TITLE
SS: install requirements properly

### DIFF
--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -88,14 +88,30 @@
 #     state: "latest"
 #   tags: "amsrc-ss-pydep"
 
-- name: "Create virtualenv for archivematica-storage-service, pip install requirements"
+- name: "Install pip requirements for production"
   pip:
     chdir: "{{ archivematica_src_dir }}/archivematica-storage-service"
-    requirements: "{{ 'requirements/test.txt' if is_dev else 'requirements.txt' }}"
+    requirements: "{{ item }}"
     virtualenv: "{{ archivematica_src_ss_virtualenv }}"
     extra_args: "{{ ss_pip_install_extra_args }}"
     state: "latest"
   tags: "amsrc-ss-pydep"
+  when: "is_prod"
+  with_items:
+    - "requirements/production.txt"
+
+- name: "Install pip requirements for development"
+  pip:
+    chdir: "{{ archivematica_src_dir }}/archivematica-storage-service"
+    requirements: "{{ item }}"
+    virtualenv: "{{ archivematica_src_ss_virtualenv }}"
+    extra_args: "{{ ss_pip_install_extra_args }}"
+    state: "latest"
+  tags: "amsrc-ss-pydep"
+  when: "is_dev"
+  with_items:
+    - "requirements/local.txt"
+    - "requirements/test.txt"
 
 ###########################################################
 #   3- OS configuration (user/directory/file creation/permissions/ownership)


### PR DESCRIPTION
Install both test.txt and local.txt when is_dev is enabled. This is needed
because some deps like dj-database-url were moved to local.txt.