### PR TITLE
Remove role dependency (geerlingguy.nodejs)

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,4 @@ galaxy_info:
     - trusty
     - xenial
 
-dependencies:
-- role: geerlingguy.nodejs
-  version: 4.1.1
-  nodejs_version: 8.x
+dependencies: []


### PR DESCRIPTION
Remove role dependency and add it to the playbook instead, for the
following reasons:
- when included as a dependency, the nodejs role is run each time the
  archivematica-src role is executed, which may not be desired (for
  example when just doing an upgrade of Archivematica)
- by putting explicitly in the playbook, it is more clear what the
  playboook does and also where to do variable fixes when required