### PR TITLE
Run npm install for appraisal-tab/transfer-browser

### DIFF
--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -103,9 +103,9 @@
 - name: "Install front-end dependencies"
   become: "yes"
   become_user: "archivematica"
-  npm:
-    path: "{{ item }}"
-    state: "present"
+  command: npm install
+  args:
+    chdir: "{{ item }}"
   with_items:
     - "{{ archivematica_src_dir }}/archivematica/src/dashboard/frontend/appraisal-tab"
     - "{{ archivematica_src_dir }}/archivematica/src/dashboard/frontend/transfer-browser"


### PR DESCRIPTION
The appraisal-tab and transfer-browser javascript files were not created
when updating AM, the files from the initial install were used.

Running `npm install` creates these files on every update.

This fixes #164