### PR TITLE
Build npm dependencies also in vagrant

### DIFF
--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -100,6 +100,9 @@
     - "{{ archivematica_src_dir }}/archivematica/src/dashboard/src/media"
     - "{{ archivematica_src_dir }}/archivematica/src/dashboard/frontend"
 
+# When code lives in a shared folder (vboxsf), this task might
+# cause errors, but works when run manually.
+
 - name: "Install front-end dependencies"
   become: "yes"
   become_user: "archivematica"
@@ -109,12 +112,6 @@
   with_items:
     - "{{ archivematica_src_dir }}/archivematica/src/dashboard/frontend/appraisal-tab"
     - "{{ archivematica_src_dir }}/archivematica/src/dashboard/frontend/transfer-browser"
-  when:
-    # We're not building the front-ends when using Vagrant because the source
-    # code lives in a shared folder (vboxsf), which is problematic and causes
-    # errors. The developer needs to build the front-ends manually for now.
-    - "ansible_env.USER != 'vagrant'"
-
 
 #
 # collectstatic


### PR DESCRIPTION
After artefactual/deploy-pub#52 is merged, we won't be using a
a shared folder for code deployment in virtualbox.