### PR TITLE
Configure AM17 logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Archivematica installation from its source code repositories.
 
 - [Role Variables](#role-variables)
 - [Environment variables](#environment-variables)
+- [Backward-compatible logging](#backward-compatible-logging)
 - [Tags](#tags)
 - [Dependencies](#dependencies)
 - [Example Playbooks](#example-playbooks)
@@ -47,6 +48,13 @@ archivematica_src_am_mcpserver_environment:
   ARCHIVEMATICA_MCPSERVER_CLIENT_HOST: "192.168.10.11"
   ARCHIVEMATICA_MCPSERVER_CLIENT_PORT: "3306"
 ```
+
+Backward-compatible logging
+---------------------------
+
+The default Archivematica 1.7 logging sends the events to the standard streams, which is more convenient when Archivematica is running in a cluster. In order to use the backward-compatible logging, the boolean environment variable `archivematica_src_logging_backward_compatible` has to be enabled, which is the default behaviour.
+
+The log file sizes and the directories to store the logs are configurable for each service. The default values can be found in [`defaults/main.yml`](defaults/main.yml).
 
 
 Tags

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,6 +85,25 @@ archivematica_src_ss_environment:
 
 
 #
+# Logging settings
+#
+
+archivematica_src_logging_backward_compatible: "yes"
+archivematica_src_dashboard_logdir: "/var/log/archivematica/dashboard"
+archivematica_src_mcpclient_logdir: "/var/log/archivematica/MCPClient"
+archivematica_src_mcpserver_logdir: "/var/log/archivematica/MCPServer"
+archivematica_src_ss_logdir: "/var/log/archivematica/storage-service"
+archivematica_src_dashboard_log_debug_maxbytes: "104857600"   # 100 MBytes
+archivematica_src_mcpclient_log_debug_maxbytes: "4194304"     #   4 Mbytes
+archivematica_src_mcpserver_log_debug_maxbytes: "4194304"     #   4 Mbytes
+archivematica_src_ss_log_debug_maxbytes: "104857600"          # 100 MBytes
+archivematica_src_dashboard_log_maxbytes: "20971520"          #  20 Mbytes
+archivematica_src_mcpclient_log_maxbytes: "4194304"           #   4 Mbytes
+archivematica_src_mcpserver_log_maxbytes: "4194304"           #   4 Mbytes
+archivematica_src_ss_log_maxbytes: "20971520"                 #  20 Mbytes
+
+
+#
 # Nginx
 #
 

--- a/tasks/pipeline-osconf.yml
+++ b/tasks/pipeline-osconf.yml
@@ -55,3 +55,56 @@
     dest: "/var/archivematica/sharedDirectory"
     state: "link"
   when: "create_shareddir and archivematica_src_shareddir != '/var/archivematica/sharedDirectory'"
+
+#
+# Backward-compatible Logging config
+# 
+
+- name: "Create archivematica log directories"
+  file:
+    dest: "{{ item }}"
+    state: "directory"
+    owner: "archivematica"
+    group: "archivematica"
+    mode: "g+s"
+  with_items:
+    - "{{ archivematica_src_dashboard_logdir }}"
+    - "{{ archivematica_src_mcpclient_logdir }}"
+    - "{{ archivematica_src_mcpserver_logdir }}"
+  when: "archivematica_src_logging_backward_compatible|bool"
+
+- name: "Configure backward-compatible logging"
+  template:
+    src: "{{ item }}"
+    dest: /etc/archivematica/{{ item | basename | regex_replace('\.j2','') }}
+    backup: "yes"
+  with_items:
+    - "etc/archivematica/dashboard.logging.json.j2"
+    - "etc/archivematica/clientConfig.logging.json.j2"
+    - "etc/archivematica/serverConfig.logging.json.j2"
+  when: "archivematica_src_logging_backward_compatible|bool"
+
+- name: "Remove backward-compatible logging"
+  file:
+    path: "{{ item }}"
+    state: "absent"
+  with_items:
+    - "/etc/archivematica/dashboard.logging.json"
+    - "/etc/archivematica/clientConfig.logging.json"
+    - "/etc/archivematica/serverConfig.logging.json"
+  when: "not archivematica_src_logging_backward_compatible|bool"
+
+- name: "Touch log files"
+  file:
+    path: "{{ item }}"
+    owner: "archivematica"
+    group: "archivematica"
+    state: "touch"
+  with_items:
+    - "{{ archivematica_src_dashboard_logdir }}/dashboard.log"
+    - "{{ archivematica_src_dashboard_logdir }}/dashboard.debug.log"
+    - "{{ archivematica_src_mcpclient_logdir }}/MCPClient.log"
+    - "{{ archivematica_src_mcpclient_logdir }}/MCPClient.debug.log"
+    - "{{ archivematica_src_mcpserver_logdir }}/MCPServer.log"
+    - "{{ archivematica_src_mcpserver_logdir }}/MCPServer.debug.log"
+  when: "archivematica_src_logging_backward_compatible|bool"

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -143,6 +143,41 @@
     - "/etc/archivematica"
   tags: "amsrc-ss-osconf"
 
+- name: "Create archivematica-storage-service log directories"
+  file:
+    dest: "{{ archivematica_src_ss_logdir }}"
+    state: "directory"
+    owner: "archivematica"
+    group: "archivematica"
+    mode: "g+s"
+  tags: "amsrc-ss-osconf"
+  when: "archivematica_src_logging_backward_compatible|bool"
+
+- name: "Touch SS log files"
+  file:
+    path: "{{ archivematica_src_ss_logdir }}/{{ item }}"
+    owner: "archivematica"
+    group: "archivematica"
+    state: "touch"
+  with_items:
+    - "storage_service.log"
+    - "storage_service_debug.log"
+  tags: "amsrc-ss-osconf"
+  when: "archivematica_src_logging_backward_compatible|bool"
+
+- name: "Config SS logging"
+  template:
+    src: "etc/archivematica/storageService.logging.json.j2"
+    dest: "/etc/archivematica/storageService.logging.json"
+    backup: "yes"
+  tags: "amsrc-ss-osconf"
+  when: "archivematica_src_logging_backward_compatible|bool"
+
+- name: "Remove SS backward-compatible logging"
+  file:
+    path: "/etc/archivematica/storageService.logging.json"
+    state: "absent"
+  when: "not archivematica_src_logging_backward_compatible|bool"
 
 ###########################################################
 #   4- SS code install

--- a/templates/etc/archivematica/clientConfig.logging.json.j2
+++ b/templates/etc/archivematica/clientConfig.logging.json.j2
@@ -1,0 +1,40 @@
+{
+  "disable_existing_loggers": false,
+  "formatters": {
+    "detailed": {
+      "datefmt": "%Y-%m-%d %H:%M:%S",
+      "format": "%(levelname)-8s  %(asctime)s  %(name)s:%(module)s:%(funcName)s:%(lineno)d:  %(message)s"
+    }
+  },
+  "handlers": {
+    "logfile": {
+      "backupCount": 5,
+      "class": "custom_handlers.GroupWriteRotatingFileHandler",
+      "filename": "{{ archivematica_src_mcpclient_logdir }}/MCPClient.log",
+      "formatter": "detailed",
+      "level": "INFO",
+      "maxBytes": {{ archivematica_src_mcpclient_log_maxbytes }}
+    },
+    "verboselogfile": {
+      "backupCount": 5,
+      "class": "custom_handlers.GroupWriteRotatingFileHandler",
+      "filename": "{{ archivematica_src_mcpclient_logdir }}/MCPClient.debug.log",
+      "formatter": "detailed",
+      "level": "DEBUG",
+      "maxBytes": {{ archivematica_src_mcpclient_log_debug_maxbytes }}
+    }
+  },
+  "loggers": {
+    "archivematica": {
+      "level": "DEBUG"
+    }
+  },
+  "root": {
+    "handlers": [
+      "logfile",
+      "verboselogfile"
+    ],
+    "level": "WARNING"
+  },
+  "version": 1
+}

--- a/templates/etc/archivematica/dashboard.logging.json.j2
+++ b/templates/etc/archivematica/dashboard.logging.json.j2
@@ -1,0 +1,80 @@
+{
+  "disable_existing_loggers": false,
+  "filters": {
+    "require_debug_false": {
+      "()": "django.utils.log.RequireDebugFalse"
+    }
+  },
+  "formatters": {
+    "detailed": {
+      "datefmt": "%Y-%m-%d %H:%M:%S",
+      "format": "%(levelname)-8s  %(asctime)s  %(name)s:%(module)s:%(funcName)s:%(lineno)d:  %(message)s"
+    },
+    "simple": {
+      "format": "%(levelname)-8s  %(name)s.%(funcName)s:  %(message)s"
+    }
+  },
+  "handlers": {
+    "console": {
+      "class": "logging.StreamHandler",
+      "formatter": "simple",
+      "level": "DEBUG"
+    },
+    "logfile": {
+      "backupCount": 5,
+      "class": "custom_handlers.GroupWriteRotatingFileHandler",
+      "filename": "{{ archivematica_src_dashboard_logdir }}/dashboard.log",
+      "formatter": "detailed",
+      "level": "INFO",
+      "maxBytes": {{ archivematica_src_dashboard_log_maxbytes }}
+    },
+    "mail_admins": {
+      "class": "django.utils.log.AdminEmailHandler",
+      "filters": [
+        "require_debug_false"
+      ],
+      "level": "ERROR"
+    },
+    "null": {
+      "class": "logging.NullHandler",
+      "level": "DEBUG"
+    },
+    "verboselogfile": {
+      "backupCount": 5,
+      "class": "custom_handlers.GroupWriteRotatingFileHandler",
+      "filename": "{{ archivematica_src_dashboard_logdir }}/dashboard.debug.log",
+      "formatter": "detailed",
+      "level": "DEBUG",
+      "maxBytes": {{ archivematica_src_dashboard_log_debug_maxbytes }}
+    }
+  },
+  "loggers": {
+    "agentarchives": {
+      "level": "INFO"
+    },
+    "archivematica": {
+      "level": "DEBUG"
+    },
+    "archivematica.mcp": {
+      "propagate": false
+    },
+    "django.request": {
+      "handlers": [
+        "mail_admins"
+      ],
+      "level": "ERROR",
+      "propagate": true
+    },
+    "elasticsearch": {
+      "level": "INFO"
+    }
+  },
+  "root": {
+    "handlers": [
+      "logfile",
+      "verboselogfile"
+    ],
+    "level": "WARNING"
+  },
+  "version": 1
+}

--- a/templates/etc/archivematica/serverConfig.logging.json.j2
+++ b/templates/etc/archivematica/serverConfig.logging.json.j2
@@ -1,0 +1,40 @@
+{
+  "disable_existing_loggers": false,
+  "formatters": {
+    "detailed": {
+      "datefmt": "%Y-%m-%d %H:%M:%S",
+      "format": "%(levelname)-8s  %(asctime)s  %(name)s:%(module)s:%(funcName)s:%(lineno)d:  %(message)s"
+    }
+  },
+  "handlers": {
+    "logfile": {
+      "backupCount": 5,
+      "class": "custom_handlers.GroupWriteRotatingFileHandler",
+      "filename": "{{ archivematica_src_mcpserver_logdir }}/MCPServer.log",
+      "formatter": "detailed",
+      "level": "INFO",
+      "maxBytes": {{ archivematica_src_mcpserver_log_maxbytes }}
+    },
+    "verboselogfile": {
+      "backupCount": 5,
+      "class": "custom_handlers.GroupWriteRotatingFileHandler",
+      "filename": "{{ archivematica_src_mcpserver_logdir }}/MCPServer.debug.log",
+      "formatter": "detailed",
+      "level": "DEBUG",
+      "maxBytes": {{ archivematica_src_mcpserver_log_debug_maxbytes }}
+    }
+  },
+  "loggers": {
+    "archivematica": {
+      "level": "DEBUG"
+    }
+  },
+  "root": {
+    "handlers": [
+      "logfile",
+      "verboselogfile"
+    ],
+    "level": "WARNING"
+  },
+  "version": 1
+}

--- a/templates/etc/archivematica/storageService.logging.json.j2
+++ b/templates/etc/archivematica/storageService.logging.json.j2
@@ -1,0 +1,83 @@
+{
+  "disable_existing_loggers": false,
+  "filters": {
+    "require_debug_false": {
+      "()": "django.utils.log.RequireDebugFalse"
+    }
+  },
+  "formatters": {
+    "detailed": {
+      "datefmt": "%Y-%m-%d %H:%M:%S",
+      "format": "%(levelname)-8s  %(asctime)s  %(name)s:%(module)s:%(funcName)s:%(lineno)d:  %(message)s"
+    },
+    "simple": {
+      "format": "%(levelname)-8s  %(name)s.%(funcName)s:  %(message)s"
+    }
+  },
+  "handlers": {
+    "console": {
+      "class": "logging.StreamHandler",
+      "formatter": "simple",
+      "level": "DEBUG"
+    },
+    "logfile": {
+      "backupCount": 5,
+      "class": "logging.handlers.RotatingFileHandler",
+      "filename": "{{ archivematica_src_ss_logdir }}/storage_service.log",
+      "formatter": "detailed",
+      "level": "INFO",
+      "maxBytes": {{ archivematica_src_ss_log_maxbytes }}
+    },
+    "mail_admins": {
+      "class": "django.utils.log.AdminEmailHandler",
+      "filters": [
+        "require_debug_false"
+      ],
+      "level": "ERROR"
+    },
+    "null": {
+      "class": "logging.NullHandler",
+      "level": "DEBUG"
+    },
+    "verboselogfile": {
+      "backupCount": 5,
+      "class": "logging.handlers.RotatingFileHandler",
+      "filename": "{{ archivematica_src_ss_logdir }}/storage_service_debug.log",
+      "formatter": "detailed",
+      "level": "DEBUG",
+      "maxBytes": {{ archivematica_src_dashboard_log_debug_maxbytes }}
+    }
+  },
+  "loggers": {
+    "administration": {
+      "level": "DEBUG"
+    },
+    "common": {
+      "level": "DEBUG"
+    },
+    "django.request": {
+      "handlers": [
+        "mail_admins"
+      ],
+      "level": "ERROR",
+      "propagate": true
+    },
+    "django.request.tastypie": {
+      "level": "ERROR"
+    },
+    "locations": {
+      "level": "DEBUG"
+    },
+    "sword2": {
+      "level": "INFO"
+    }
+  },
+  "root": {
+    "handlers": [
+      "logfile",
+      "verboselogfile"
+    ],
+    "level": "WARNING"
+  },
+  "version": 1
+}


### PR DESCRIPTION
A new option to configure backward-compatible logging has been added to
substitute the new AM17 logging setup. The default AM17 logging sends
the events to the standard streams, which is more convenient when
Archivematica is running in a cluster.

In order to use the backward-compatible logging, the boolean environment
variable 'archivematica_src_logging_backward_compatible' has to be
enabled, which is the default behaviour.

The log directory paths and log file sizes are configurable for each
service.

Fixes #147.