### PR TITLE
Build npm dependencies always

### DIFF
--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -109,12 +109,6 @@
   with_items:
     - "{{ archivematica_src_dir }}/archivematica/src/dashboard/frontend/appraisal-tab"
     - "{{ archivematica_src_dir }}/archivematica/src/dashboard/frontend/transfer-browser"
-  when:
-    # We're not building the front-ends when using Vagrant because the source
-    # code lives in a shared folder (vboxsf), which is problematic and causes
-    # errors. The developer needs to build the front-ends manually for now.
-    - is_prod or (is_dev and "ansible_env.USER != 'vagrant'")
-
 
 #
 # collectstatic


### PR DESCRIPTION
The npm problem was caused by a permissions problem, that can be fixed in the vagrantfile by configuring the shared folder like this:

  config.vm.synced_folder '.', '/vagrant',mount_options: ["uid=333", "gid=333"]

Refs: https://github.com/artefactual/deploy-pub/pull/52