### PR TITLE
Add update apt cache in MCPClient ospdeps

### DIFF
--- a/tasks/pipeline-osdeps-MCPClient.yml
+++ b/tasks/pipeline-osdeps-MCPClient.yml
@@ -19,6 +19,10 @@
       when:
         - "MCPClient.osdeps_repos"
 
+    - name: "Update APT package manager repositories cache"
+      apt:
+        update_cache: "yes"
+
     - name: "Install MCPClient ext. package deps."
       apt:
         pkg: "{{ item['name'] }}"


### PR DESCRIPTION
An apt cache refresh is needed after adding 2 new apt repositories in `pipeline-osdeps-MCPClient.yml`

it fixes #176 