### PR TITLE
Update createtranfers.py path and commands

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -132,7 +132,10 @@
   become: "no"
 
 - name: "Generate special sampledata transfers"
-  command: "~/archivematica-sampledata/createtransfers.py create-variously-encoded-files"
+  command: "~/archivematica-sampledata/createtransfers/createtransfers.py {{ item }}"
+  with_items:
+    - "create-variously-encoded-files"
+    - "create-deep-transfers"
   when: "archivematica_src_install_sample_data|bool"
   become: "no"
 


### PR DESCRIPTION
The `createtranfers.py` path and commands have been changed at the `archivematica-sampledata` repo. This PR will update then.

This fixes #180.