### PR TITLE
Change default virtualenv directories

### DIFF
--- a/tasks/acceptance-tests.yml
+++ b/tasks/acceptance-tests.yml
@@ -17,11 +17,17 @@
     version: "{{ archivematica_src_acceptance_tests_version }}"
     force: "yes"
 
+# this task is needed to avoid problems when upgrading python package
+- name: "Remove old virtualenv default dir"
+  file:
+    state: absent
+    path: "/usr/share/python/archivematica-acceptance-tests/"
+
 - name: "Install pip dependencies in virtualenv"
   pip:
     chdir: "{{ archivematica_src_dir }}/archivematica-acceptance-tests"
     requirements: "requirements.txt"
-    virtualenv: "/usr/share/python/archivematica-acceptance-tests"
+    virtualenv: "/usr/share/archivematica/virtualenvs/archivematica-acceptance-tests"
     virtualenv_python: "python3"
     state: latest
 

--- a/tasks/pipeline-pip-deps.yml
+++ b/tasks/pipeline-pip-deps.yml
@@ -1,4 +1,13 @@
 ---
+# this task is needed to avoid problems when upgrading python package
+- name: "virtualenv | Remove old virtualenv default dirs"
+  file:
+    state: absent
+    path: "/usr/share/python/{{ item }}/"
+  with_items:
+    - "archivematica-dashboard"
+    - "archivematica-mcp-client"
+    - "archivematica-mcp-server"
 
 - name: "virtualenv | Set `virtualenvs` variable"
   set_fact:

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -56,7 +56,11 @@
   when: "ss_lib_dir_check.stat.isdir is defined and ss_lib_dir_check.stat.isdir"
   tags: "amsrc-ss-pydep"
 
-
+# this task is needed to avoid problems when upgrading python package
+- name: "Remove old SS virtualenv default dir"
+  file:
+    state: absent
+    path: "/usr/share/python/archivematica-storage-service/"
 
 # a separate task to create the virtualenv before install requirements
 # is required to avoid errors

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,18 +1,18 @@
 ---
 ansible_deps: []
 
-archivematica_src_am_dashboard_virtualenv: "/usr/share/python/archivematica-dashboard"
+archivematica_src_am_dashboard_virtualenv: "/usr/share/archivematica/virtualenvs/archivematica-dashboard"
 archivematica_src_am_dashboard_app: "/usr/share/archivematica/dashboard"
 archivematica_src_am_dashboard_gunicorn_config: "/etc/archivematica/dashboard.gunicorn-config.py"
 
-archivematica_src_am_mcpserver_virtualenv: "/usr/share/python/archivematica-mcp-server"
+archivematica_src_am_mcpserver_virtualenv: "/usr/share/archivematica/virtualenvs/archivematica-mcp-server"
 archivematica_src_am_mcpserver_app: "/usr/lib/archivematica/MCPServer"
 
-archivematica_src_am_mcpclient_virtualenv: "/usr/share/python/archivematica-mcp-client"
+archivematica_src_am_mcpclient_virtualenv: "/usr/share/archivematica/virtualenvs/archivematica-mcp-client"
 archivematica_src_am_mcpclient_app: "/usr/lib/archivematica/MCPClient"
 
 archivematica_src_am_common_app: "/usr/lib/archivematica/archivematicaCommon"
 
-archivematica_src_ss_virtualenv: "/usr/share/python/archivematica-storage-service"
+archivematica_src_ss_virtualenv: "/usr/share/archivematica/virtualenvs/archivematica-storage-service"
 archviematica_src_ss_app: "/usr/lib/archivematica/storage-service"
 archivematica_src_ss_gunicorn_config: "/etc/archivematica/storage-service.gunicorn-config.py"


### PR DESCRIPTION
This PR will change the default virtualenv directories to avoid problems when upgrading the python-minimal package.

   * From: /usr/share/python/archivematica-*
   * To:   /usr/share/archivematica/virtualenvs/archivematica-*

Fixes #178 