### PR TITLE
Configure the ClamAV socket in MCP-Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ The default Archivematica 1.7 logging sends the events to the standard streams, 
 
 The log file sizes and the directories to store the logs are configurable for each service. The default values can be found in [`defaults/main.yml`](defaults/main.yml).
 
+Configure ClamAV
+----------------
+
+This role will try to determine whether the ClamAV daemon is running using the TCP or UNIX socket on the same server that the pipeline is being installed or updated on. To configure an external ClamAV daemon server, the following env vars should be set: 
+
+```yaml
+---
+archivematica_src_mcpclient_clamav_use_tcp: "yes"
+archivematica_src_mcpclient_clamav_tcp_ip: "1.2.3.4"
+archivematica_src_mcpclient_clamav_tcp_port: "3310"
+```
+
 Disable Elasticsearch use
 -------------------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,6 +110,16 @@ archivematica_src_ss_environment:
   REQUEST_CA_BUNDLE: "{{ archivematica_src_ca_custom_bundle }}"
 
 #
+# Clamav settings
+#
+
+# The following variables can be used to disable the Clamav daemon socket check and force the TCP socket configuration. When the Clamav daemon is not running on the same server than the pipeline, these variables have to be set to configure the Clamav daemon in the MCPClient
+
+archivematica_src_mcpclient_clamav_use_tcp: "no"
+archivematica_src_mcpclient_clamav_tcp_ip: "localhost"
+archivematica_src_mcpclient_clamav_tcp_port: "3310"
+
+#
 # Logging settings
 #
 

--- a/tasks/pipeline-osconf.yml
+++ b/tasks/pipeline-osconf.yml
@@ -56,17 +56,18 @@
     state: "link"
   when: "create_shareddir and archivematica_src_shareddir != '/var/archivematica/sharedDirectory'"
 
-# check if clamav is running with file or tcp socket
-- name: "Check if clamav is running with file or tcp socket"
+# check if ClamAV is running with file or tcp socket
+- name: "Check if ClamAV is running with file or tcp socket"
   shell: cat /etc/clamav/clamd.conf /etc/clamd.conf 2> /dev/null | grep -Eq "^LocalSocket\ "
   register: clamavlocalsocket
   check_mode: no
   failed_when: clamavlocalsocket.rc > 1
   changed_when: false
+  when: "not archivematica_src_mcpclient_clamav_use_tcp|bool"
 
 - set_fact:
     clamav_uses_file_socket: true
-  when: clamavlocalsocket.rc == 0
+  when: clamavlocalsocket.rc is defined and clamavlocalsocket.rc == 0
 
 #
 # Backward-compatible Logging config

--- a/tasks/pipeline-osconf.yml
+++ b/tasks/pipeline-osconf.yml
@@ -56,6 +56,18 @@
     state: "link"
   when: "create_shareddir and archivematica_src_shareddir != '/var/archivematica/sharedDirectory'"
 
+# check if clamav is running with file or tcp socket
+- name: "Check if clamav is running with file or tcp socket"
+  shell: cat /etc/clamav/clamd.conf /etc/clamd.conf 2> /dev/null | grep -Eq "^LocalSocket\ "
+  register: clamavlocalsocket
+  check_mode: no
+  failed_when: clamavlocalsocket.rc > 1
+  changed_when: false
+
+- set_fact:
+    clamav_uses_file_socket: true
+  when: clamavlocalsocket.rc == 0
+
 #
 # Backward-compatible Logging config
 # 

--- a/templates/etc/sysconfig/archivematica-mcp-client.j2
+++ b/templates/etc/sysconfig/archivematica-mcp-client.j2
@@ -7,6 +7,6 @@ PYTHONPATH={{ archivematica_src_am_mcpclient_app }}:{{ archivematica_src_am_comm
 {{ key }}={{ value }}
 {% endfor %}
 
-{% if clamav_uses_file_socket is not defined %}
-ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_SERVER=localhost:3310
+{% if clamav_uses_file_socket is not defined or archivematica_src_mcpclient_clamav_use_tcp|bool %}
+ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_SERVER={{ archivematica_src_mcpclient_clamav_tcp_ip  }}:{{ archivematica_src_mcpclient_clamav_tcp_port }}
 {% endif %}

--- a/templates/etc/sysconfig/archivematica-mcp-client.j2
+++ b/templates/etc/sysconfig/archivematica-mcp-client.j2
@@ -6,3 +6,7 @@ PYTHONPATH={{ archivematica_src_am_mcpclient_app }}:{{ archivematica_src_am_comm
 {% for key, value in archivematica_src_am_mcpclient_environment.iteritems() %}
 {{ key }}={{ value }}
 {% endfor %}
+
+{% if clamav_uses_file_socket is not defined %}
+ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_SERVER=localhost:3310
+{% endif %}


### PR DESCRIPTION
This PR will detect if ClamAV daemon is running on UNIX socket or TCP
socket and configures the default/sysconfig MCP-Client file to use the
TCP socket if needed.

It fixes #185 