### PR TITLE
Don't start mcp-s until mysql is running

### DIFF
--- a/templates/etc/systemd/system/archivematica-mcp-server.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-server.service.j2
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=Archivematica MCP Server Service
-After=syslog.target network.target
+After=syslog.target network.target mysql.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
This is the same change that was done on:

https://github.com/artefactual-labs/am-packbuild/pull/112

The `mysql.service` is used for CentOS and Ubuntu because the
artefactual-labs/ansible-mariadb role uses `mysql.service` on systemd.

it fixes #186