### PR TITLE
am-configure: enhance SS user configuration

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -5,6 +5,16 @@
 - set_fact: archivematica_src_configure_ss_api_key={{ 999999999999999999999 | random | to_uuid | hash('md5') }}
   when: "archivematica_src_configure_ss_api_key is undefined and archivematica_src_configure_ss|bool"
 
+# Check whether SS user exists
+- name:  Check SS default test user
+  become: "yes"
+  command: sqlite3  "{{archivematica_src_ss_environment['SS_DB_NAME']}}" "select username from auth_user where (id=1 and last_login is NULL and first_name='' and last_name='' and email='x@x.com' and username='test');"
+  register: ss_default_test_user
+
+- debug:
+    msg: "The SS default test user is already configured and never was used: this user will be deleted."
+  when: ss_default_test_user.stdout != "" and archivematica_src_configure_ss|bool
+
 # Delete default SS superuser test
 - name: "Delete default SS superuser"
   become: "yes"
@@ -14,7 +24,17 @@
     chdir: "{{ archviematica_src_ss_app }}"
     executable: /bin/bash
   environment: "{{ archivematica_src_ss_environment }}"
-  when: "archivematica_src_configure_ss|bool"
+  when: archivematica_src_configure_ss|bool and ss_default_test_user.stdout != ""
+
+# Check whether SS user exists
+- name:  Check SS user
+  become: "yes"
+  command: sqlite3  "{{archivematica_src_ss_environment['SS_DB_NAME']}}" "select username from auth_user where username='{{ archivematica_src_configure_ss_user }}';"
+  register: ss_user
+
+- debug:
+    msg: "The SS user {{ archivematica_src_configure_ss_user }} is already configured: The SS superuser will not be created."
+  when: ss_user.stdout != "" and archivematica_src_configure_ss|bool
 
 - name: "Create SS superuser"
   django_manage:
@@ -28,12 +48,11 @@
     app_path: "{{ archviematica_src_ss_app }}"
     virtualenv: "{{ archivematica_src_ss_virtualenv }}"
   environment: "{{ archivematica_src_ss_environment }}"
-  when: "archivematica_src_configure_ss|bool"
+  when: archivematica_src_configure_ss|bool and ss_user.stdout == ""
 
 # dashboard-configure
 
 # Check whether pipeline is registered and dashboard user exists
-
 - name:  Check Dashboard SS url
   become: "yes"
   command: mysql {{ archivematica_src_am_db_name }} -Ns -e "select * from DashboardSettings where name='storage_service_url'"
@@ -51,7 +70,6 @@
 - debug:
     msg: "The dashboard user {{ archivematica_src_configure_am_user }} is already configured: The dashboard superuser will not be created and the pipeline will not be registered."
   when: dashboard_user.stdout != "" and archivematica_src_configure_dashboard|bool
-
 
 # Create api-key if not defined
 - set_fact: archivematica_src_configure_am_api_key={{ 999999999999999999998 | random | to_uuid | hash('md5') }}
@@ -75,4 +93,4 @@
     pythonpath: "{{ archivematica_src_am_common_app }}"
     virtualenv: "{{ archivematica_src_am_dashboard_virtualenv }}"
   environment: "{{ archivematica_src_am_dashboard_environment }}"
-  when: archivematica_src_configure_dashboard|bool and dashboard_user.stdout == "" and  dashboard_user.stdout == ""
+  when: archivematica_src_configure_dashboard|bool and dashboard_user.stdout == "" and dashboard_ss_url.stdout == ""

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,4 +4,5 @@ ansible_deps:
   - "python-pycurl"
   - "git"
   - "python-mysqldb" # Required for mysql_db module
+  - "sqlite3"        # Required for am-configure and fixity
 ca_custom_bundle: "/etc/ssl/certs/ca-certificates.crt"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,4 +4,5 @@ ansible_deps:
   - "epel-release"
   - "git"
   - "MySQL-python" # Required for mysql_db module
+  - "sqlite"       # Required for am-configure and fixity
 ca_custom_bundle: "/etc/pki/tls/certs/ca-bundle.crt"


### PR DESCRIPTION
    This commit will:
    
    - Enhance configure SS user #1: Detect and delete the default SS test when id=1
    on SS database and never was used. This way the role avoids to delete a
    possible "test" user added by an admin or by this role.
    
    - Enhance configure SS user #2: Check whether SS user already exists. In this
    case the SS user is not modified.
    
    - Enhance configure Dashboard user: Fix conditional typo at "Create Dashboard
    user and register pipeline on SS"
    
    - Add sqlite3 as OS dependency (Needed to check SS user on SS database)

Fixes https://github.com/artefactual-labs/ansible-archivematica-src/issues/222