### PR TITLE
Add epel-release and extra repos for RHEL

### DIFF
--- a/tasks/common-RHEL.yml
+++ b/tasks/common-RHEL.yml
@@ -1,0 +1,19 @@
+---
+
+#
+# Install epel-release rpm package
+#
+
+- name: "Install EPEL repository on RHEL"
+  yum:
+    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    state: "present"
+
+#
+# Install optional and extras repoisitories because EPEL packages may depend on
+# packages from these repositories. 
+# See: https://github.com/artefactual-labs/ansible-archivematica-src/issues/209
+#
+
+- name: "Add rhel-*-optional-rpms repo on RHEL"
+  command: subscription-manager repos --enable "rhel-*-optional-rpms" --enable "rhel-*-extras-rpms"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,10 @@
     is_prod: "{{ archivematica_src_environment_type == 'production' }}"
   tags: "always" # inocuous to use always here
 
+- name: "Include common-RHEL.yml for RHEL"
+  include: "common-RHEL.yml"
+  when: "ansible_distribution == 'RedHat'"
+
 - name: "Install necessary packages required by this role"
   package:
     name: "{{ item }}"


### PR DESCRIPTION
RHEL doesn't include the `epel-release` package on its official repositories,
so it is needed to install the `epel-release`rpm package from the fedoraproject
homepage.

It is recommended to also enable the optional and extras repositories since
EPEL packages may depend on packages from these repositories.

Connects to https://github.com/archivematica/Issues/issues/155
Connects to https://github.com/artefactual-labs/ansible-archivematica-src/issues/209