### PR TITLE
Remove curator and delete indexes using ansible module

### DIFF
--- a/tasks/pipeline-es.yml
+++ b/tasks/pipeline-es.yml
@@ -2,20 +2,20 @@
 
 - block:
 
-    - name: "pipeline-es | Install elasticsearch-curator"
-      pip:
-        name: "elasticsearch-curator"
-        version: "3.5.1"
-
     - name: "pipeline-es | Set Elasticsearch connection parameters"
       set_fact:
         es_host: "{{ archivematica_src_am_dashboard_environment['ARCHIVEMATICA_DASHBOARD_DASHBOARD_ELASTICSEARCH_SERVER'] | regex_replace('^(?P<host>.+):(?P<port>\\d+)$', '\\g<host>') }}"
         es_port: "{{ archivematica_src_am_dashboard_environment['ARCHIVEMATICA_DASHBOARD_DASHBOARD_ELASTICSEARCH_SERVER'] | regex_replace('^(?P<host>.+):(?P<port>\\d+)$', '\\g<port>') }}"
 
     - name: "pipeline-es | Reset Elasticsearch indexes"
-      command: "curator --host={{ es_host }} --port={{ es_port }} delete indices --index='{{ item }}'"
+      uri:
+        url: "http://{{ es_host }}:{{es_port}}/{{ item }}"
+        method: "DELETE"
       with_items:
-        - "transfers"
         - "aips"
+        - "transfers"
+        - "transferfiles"
+        - "aipfiles"
+      ignore_errors: True
 
   when: "archivematica_src_reset_es|bool or archivematica_src_reset_am_all|bool"


### PR DESCRIPTION
Due to the introduction of ES6 in AM 1.9, this removes the dependency
on curator instead of updating it to work with newer ElasticSearch versions

Connects to https://github.com/artefactual/archivematica/issues/1171