### PR TITLE
Use LC_LANG=C.UTF-8 for MCPClient

### DIFF
--- a/templates/etc/sysconfig/archivematica-mcp-client.j2
+++ b/templates/etc/sysconfig/archivematica-mcp-client.j2
@@ -1,5 +1,7 @@
 # {{ ansible_managed }}
 
+LC_ALL=C.UTF-8
+
 PATH={{ archivematica_src_am_mcpclient_virtualenv }}/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
 PYTHONPATH={{ archivematica_src_am_mcpclient_app }}:{{ archivematica_src_am_common_app }}:{{ archivematica_src_am_dashboard_app }}
 


### PR DESCRIPTION
We use a similar workaround in storage service ( https://github.com/artefactual-labs/ansible-archivematica-src/blob/qa/1.x/templates/etc/sysconfig/archivematica-storage-service.j2#L3 )

Connects to https://github.com/archivematica/Issues/issues/506