### PR TITLE
Remove old sudoers archivematica user line

### DIFF
--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -49,7 +49,16 @@
     regexp: "^archivematica ALL\\="
     line: "archivematica ALL=NOPASSWD:/bin/mv,/bin/chown,/bin/chmod,/usr/bin/find,/usr/bin/gs,/usr/bin/inkscape"
     validate: "/usr/sbin/visudo -cf %s"
+  when: archivematica_src_enable_sudoers is defined and archivematica_src_enable_sudoers|bool
 
+- name: "Remove archivematica user permissions in visudo file"
+  lineinfile:
+    dest: "/etc/sudoers"
+    state: "absent"
+    regexp: "^archivematica ALL\\="
+    line: "archivematica ALL=NOPASSWD:/bin/mv,/bin/chown,/bin/chmod,/usr/bin/find,/usr/bin/gs,/usr/bin/inkscape"
+    validate: "/usr/sbin/visudo -cf %s"
+  when: archivematica_src_enable_sudoers is not defined or not archivematica_src_enable_sudoers|bool
 
 #
 # Prepare `archivematica_src_dir`


### PR DESCRIPTION
This pull request removes the `/etc/sudoers` archivematica user line:
```
archivematica ALL=NOPASSWD:/bin/mv,/bin/chown,/bin/chmod,/usr/bin/find,/usr/bin/gs,/usr/bin/inkscape
```
This line is unnecessary on latest Archivematica versions. To add this `sudoers` line, please use the variable:

```
archivematica_src_enable_sudoers: "true"
```

Connects to https://github.com/archivematica/Issues/issues/537