### PR TITLE
pipeline-websrv: Fix remove default nginx site

### DIFF
--- a/tasks/pipeline-websrv-gunicorn.yml
+++ b/tasks/pipeline-websrv-gunicorn.yml
@@ -55,8 +55,8 @@
     path: "{{ item }}"
     state: "absent"
   with_items:
-    - "/etc/nginx/sites-available/default"
-    - "/etc/nginx/sites-available/default.conf"
+    - "/etc/nginx/sites-enabled/default"
+    - "/etc/nginx/sites-enabled/default.conf"
 
 - name: "Set up Nginx server"
   file:


### PR DESCRIPTION
This commit changes the task "Remove Nginx default server", deleting the
enabled default site instead of the available one. When deploying AM
pipeline only, the nginx fails to start because exists the enabled
directory default file but not the available directory one.

When deploying pipelines and ss this issue does not happen because the
enabled default file was deleted by the ss-websrv "Remove Nginx default
server" task.

Connects to  https://github.com/archivematica/Issues/issues/577