### PR TITLE
systemd: Add 5 retries to systemd dashboard

### DIFF
--- a/templates/etc/systemd/system/archivematica-dashboard.service.j2
+++ b/templates/etc/systemd/system/archivematica-dashboard.service.j2
@@ -3,6 +3,8 @@
 [Unit]
 Description=Archivematica Dashboard
 After=syslog.target network.target
+StartLimitInterval=200
+StartLimitBurst=5
 
 [Service]
 PIDFile=/run/archivematica-dashboard_gunicorn.pid
@@ -14,6 +16,8 @@ ExecStart={{ dashboard_gunicorn_path }} --config {{ archivematica_src_am_dashboa
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true
+Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The elasticsearch service can take several seconds for listening in 9200
port after systemd says it is up and running. Adding the retries to the
dashboard systemd file will fix the issue.

Connects to https://github.com/archivematica/Issues/issues/600