### PR TITLE
Add higher default timeouts, and vars for easy configuration

### DIFF
--- a/vars/envs.yml
+++ b/vars/envs.yml
@@ -6,25 +6,43 @@
 _archivematica_src_am_dashboard_environment:
   DJANGO_SETTINGS_MODULE: "settings.production"
   ARCHIVEMATICA_DASHBOARD_DASHBOARD_DJANGO_ALLOWED_HOSTS: "*"
-  ARCHIVEMATICA_DASHBOARD_DASHBOARD_DJANGO_SECRET_KEY: "CHANGE_ME_WITH_A_SECRET_KEY"
+
+
+  ARCHIVEMATICA_DASHBOARD_DASHBOARD_DJANGO_SECRET_KEY: '{{ archivematica_src_am_django_secret_key | default("CHANGE_ME_WITH_A_SECRET_KEY") }}'
   AM_GUNICORN_BIND: "127.0.0.1:8002"
   ARCHIVEMATICA_DASHBOARD_DASHBOARD_ELASTICSEARCH_SERVER: "127.0.0.1:9200"
+  ARCHIVEMATICA_DASHBOARD_DASHBOARD_STORAGE_SERVICE_CLIENT_QUICK_TIMEOUT: "{{ archivematica_src_ss_client_quick_timeout | default(20) }}"
+  ARCHIVEMATICA_DASHBOARD_DASHBOARD_ELASTICSEARCH_TIMEOUT: "{{ archivematica_src_elasticsearch_timeout | default('30') }}"
+
 
 # Base hash for archivematica_src_am_dashboard_environment.
 _archivematica_src_am_mcpserver_environment:
   DJANGO_SETTINGS_MODULE: "settings.common"
+  ARCHIVEMATICA_MCPSERVER_MCPSERVER_STORAGE_SERVICE_CLIENT_QUICK_TIMEOUT: "{{ archivematica_src_ss_client_quick_timeout | default(20) }}"
+
 
 # Base hash for archivematica_src_am_mcpclient_environment.
 _archivematica_src_am_mcpclient_environment:
   DJANGO_SETTINGS_MODULE: "settings.common"
+  ARCHIVEMATICA_MCPCLIENT_EMAIL_BACKEND: "django.core.mail.backends.smtp.EmailBackend"
+  ARCHIVEMATICA_MCPCLIENT_EMAIL_HOST: "127.0.0.1"
+  ARCHIVEMATICA_MCPCLIENT_EMAIL_PORT: "25"
+  ARCHIVEMATICA_MCPCLIENT_EMAIL_USE_TLS: "False"
+  ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_ELASTICSEARCHTIMEOUT: "{{ archivematica_src_elasticsearch_timeout | default(30) }}"
+  ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_STORAGE_SERVICE_CLIENT_QUICK_TIMEOUT: "{{ archivematica_src_ss_client_quick_timeout | default(20) }}"
+
 
 # Base hash for archivematica_src_ss_environment.
 _archivematica_src_ss_environment:
   DJANGO_SETTINGS_MODULE: "storage_service.settings.production"
   DJANGO_ALLOWED_HOSTS: "*"
-  DJANGO_SECRET_KEY: "CHANGE_ME_WITH_A_SECRET_KEY"
+  DJANGO_SECRET_KEY: '{{ archivematica_src_ss_django_secret_key | default("CHANGE_ME_WITH_A_SECRET_KEY") }}'
   SS_DB_HOST: ""
   SS_DB_NAME: "/var/archivematica/storage-service/storage.db"
   SS_DB_PASSWORD: ""
   SS_DB_USER: ""
   SS_GUNICORN_BIND: "127.0.0.1:8001"
+  EMAIL_HOST: "localhost"
+  EMAIL_HOST_PASSWORD: ""
+  EMAIL_HOST_USER: ""
+  EMAIL_PORT: "25"


### PR DESCRIPTION
This commit adds 4 new ansible vars:
 - archivematica_src_ss_client_quick_timeout
 - archivematica_src_elasticsearch_timeout
 - archivematica_src_am_django_secret_key
 - archivematica_src_ss_django_secret_key

Than can still be overriden by adding the full _environment hashes
