### PR TITLE
Add configure GPG locations

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,6 +142,20 @@ archivematica_src_configure_am_org_name: "test org"              # Dashboard adm
 archivematica_src_configure_am_org_id: "test id"                # Dashboard admin Org id
 archivematica_src_configure_am_whitelist: '""'               # Dashboard API whitelist, IP address or hostnames separated by blank spaces and inside quotes
 
+# Configure GPG
+# Uncomment this to add GPG AIPs Store and Backlog locations.
+#archivematica_src_configure_gpg:
+#  gpg_home_directory: "/var/archivematica/storage_service"
+#  binary: "gpg"
+#  key_user: "{{ archivematica_src_configure_ss_user }}"
+#  key_passphrase: "passphrase"
+#  key_comment: "Ansible Generated"
+#  key_mail: "{{ archivematica_src_configure_ss_email }}"
+#  space_staging_directory: "/var/archivematica/storage_service"
+#  aipstore_path: "/var/archivematica/sharedDirectory/www/GPG_AIPsStore"
+#  aipstore_description: "GPG AIPsStore"
+#  backlog_path: "/var/archivematica/sharedDirectory/www/GPG_transferBacklog"
+#  backlog_description: "GPG TransferBacklog"
 
 # Uncomment this to override values from DashboardSettings table.
 #archivematica_src_configure_dashboardsettings:

--- a/tasks/configure-gpg.yml
+++ b/tasks/configure-gpg.yml
@@ -1,0 +1,165 @@
+---
+
+# check when GPG Space already exists
+
+- name: "Get GPG Spaces from API"
+  uri:
+    url: "{{ archivematica_src_configure_ss_url }}/api/v2/space/?access_protocol=GPG"
+    headers:
+      Authorization: "ApiKey {{ archivematica_src_configure_ss_user }}:{{ archivematica_src_configure_ss_api_key }}"
+    status_code: 200
+    method: GET
+  register: gpg_list_gpg_spaces
+
+# add GPG space and locations when there is no GPG space already configured
+- name: "Add GPG space and locations"
+  block:
+
+    - name: "Set gpg binary name"
+      set_fact:
+        gpg_binary: "gpg1"
+      when: "ansible_distribution_version | version_compare('18.04', '>=')"
+
+    - name: "Create batch file for GPG key"
+      template:
+        src: "gpg/gpg-batch-file.j2"
+        dest: "/tmp/gpg-batch-file"
+      become: "yes"
+
+    - name: "Check whether GPG already exists"
+      shell: >
+        {{ archivematica_src_configure_gpg.binary }}
+        --no-tty
+        --homedir={{ archivematica_src_configure_gpg.gpg_home_directory }}
+        --quiet
+        --list-secret-keys
+        --fingerprint {{ archivematica_src_configure_gpg.key_user }}
+      args:
+        executable: "/bin/bash"
+      register: "gpg_key_already_exist"
+      become: "yes"
+      become_user: "archivematica"
+      ignore_errors: "yes"
+
+    - name: "Create GPG key when doesn't exist"
+      shell: >
+        {{ archivematica_src_configure_gpg.binary }}
+        --batch
+        --no-tty
+        --homedir={{ archivematica_src_configure_gpg.gpg_home_directory }}
+        --quiet
+        --gen-key
+        /tmp/gpg-batch-file
+      args:
+        executable: "/bin/bash"
+      become: "yes"
+      become_user: "archivematica"
+      when: gpg_key_already_exist.rc != 0
+      ignore_errors: "yes"
+
+    - name: "Delete GPG tmp file"
+      file:
+        state: absent
+        path: "/tmp/gpg-batch-file"
+      become: "yes"
+
+    - name: "Get gpg key fingerprint"
+      shell: >
+        {{ archivematica_src_configure_gpg.binary }}
+        --no-tty
+        --homedir={{ archivematica_src_configure_gpg.gpg_home_directory }}
+        --quiet
+        --list-secret-keys
+        --fingerprint {{ archivematica_src_configure_gpg.key_user }}
+        | grep "Key fingerprint"
+        | awk -F= '{ print $2}'
+        | tail -n1
+        | sed 's/\s//g'
+      args:
+        executable: "/bin/bash"
+      register: "gpg_fingerprint"
+      become: "yes"
+      become_user: "archivematica"
+
+    - name: "Create GPG Space"
+      uri:
+        url: "{{ archivematica_src_configure_ss_url }}/api/v2/space/"
+        headers:
+          Content-Type: "application/json"
+          Authorization: "ApiKey {{ archivematica_src_configure_ss_user }}:{{ archivematica_src_configure_ss_api_key }}"
+        body:
+          access_protocol: "GPG"
+          path: "/"
+          staging_path: "{{ archivematica_src_configure_gpg.space_staging_directory }}"
+          key: "{{ gpg_fingerprint.stdout }}"
+        body_format: json
+        status_code: 201
+        method: POST
+
+    - name: "List GPG Spaces from API"
+      uri:
+        url: "{{ archivematica_src_configure_ss_url }}/api/v2/space/?access_protocol=GPG"
+        headers:
+          Authorization: "ApiKey {{ archivematica_src_configure_ss_user }}:{{ archivematica_src_configure_ss_api_key }}"
+        status_code: 200
+        method: GET
+      register: gpg_list_gpg_spaces_again
+
+    - name: "List pipelines from API"
+      uri:
+        url: "{{ archivematica_src_configure_ss_url }}/api/v2/pipeline/"
+        headers:
+          Authorization: "ApiKey {{ archivematica_src_configure_ss_user }}:{{ archivematica_src_configure_ss_api_key }}"
+        status_code: 200
+        method: GET
+      register: gpg_list_pipelines
+
+    - name: "Create directories for GPG locations"
+      file:
+        path: "{{ item }}"
+        owner: "archivematica"
+        group: "archivematica"
+        mode: "0755"
+        state: "directory"
+      become: "yes"
+      with_items:
+        - "{{ archivematica_src_configure_gpg.aipstore_path }}"
+        - "{{ archivematica_src_configure_gpg.backlog_path }}"
+
+    - name: "Create GPG AIPs Storage"
+      uri:
+        url: "{{ archivematica_src_configure_ss_url }}/api/v2/location/"
+        headers:
+          Content-Type: "application/json"
+          Authorization: "ApiKey {{ archivematica_src_configure_ss_user }}:{{ archivematica_src_configure_ss_api_key }}"
+        body:
+          pipeline: ["/api/v2/pipeline/{{ gpg_list_pipelines.json|json_query('objects[*].uuid')|first }}/"]
+          purpose: "AS"
+          relative_path: "{{ archivematica_src_configure_gpg.aipstore_path | regex_replace('^\\/', '') }}"
+          description: "{{ archivematica_src_configure_gpg.aipstore_description }}"
+          default: "false"
+          space: "/api/v2/space/{{ gpg_list_gpg_spaces_again.json|json_query('objects[*].uuid')|first }}/"
+        body_format: json
+        status_code: 201
+        method: POST
+      when: gpg_list_gpg_spaces.json is defined and gpg_list_pipelines.json is defined
+      
+    - name: "Create GPG Transfer Backlog"
+      uri:
+        url: "{{ archivematica_src_configure_ss_url }}/api/v2/location/"
+        headers:
+          Content-Type: "application/json"
+          Authorization: "ApiKey {{ archivematica_src_configure_ss_user }}:{{ archivematica_src_configure_ss_api_key }}"
+        body:
+          pipeline: ["/api/v2/pipeline/{{ gpg_list_pipelines.json|json_query('objects[*].uuid')|first }}/"]
+          purpose: "BL"
+          relative_path: "{{ archivematica_src_configure_gpg.aipstore_path | regex_replace('^\\/', '') }}"
+          description: "{{ archivematica_src_configure_gpg.aipstore_description }}"
+          default: "false"
+          space: "/api/v2/space/{{ gpg_list_gpg_spaces_again.json|json_query('objects[*].uuid')|first }}/"
+        body_format: json
+        status_code: 201
+        method: POST
+      when: gpg_list_gpg_spaces.json is defined and gpg_list_pipelines.json is defined
+
+  when: gpg_list_gpg_spaces.json|json_query('meta.total_count') == 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -241,3 +241,12 @@
   tags:
     - "amsrc-configure"
   when: "archivematica_src_configure_ss|bool or archivematica_src_configure_dashboard|bool"
+
+#
+# Configure GPG locations
+#
+
+- include: "configure-gpg.yml"
+  tags:
+    - "amsrc-configure"
+  when: "archivematica_src_install_ss|bool and archivematica_src_configure_gpg is defined"

--- a/templates/gpg/gpg-batch-file.j2
+++ b/templates/gpg/gpg-batch-file.j2
@@ -1,0 +1,13 @@
+%echo Generating a basic OpenPGP key
+Key-Type: RSA
+Key-Length: 4096
+Subkey-Type: ELG-E
+Subkey-Length: 4096
+Name-Real: {{ archivematica_src_configure_gpg.key_user }}
+Name-Comment: {{ archivematica_src_configure_gpg.key_comment }}
+Name-Email: {{ archivematica_src_configure_gpg.key_mail }}
+Expire-Date: 0
+Passphrase: {{ archivematica_src_configure_gpg.key_passphrase }}
+# Do a commit here, so that we can later print "done" :-)
+%commit
+%echo done


### PR DESCRIPTION
When the `archivematica_src_configure_gpg` is defined, this commit adds
a new GPG space if it doesn't already exist and configures a GPG AIPs
Store and a GPG Transfer Backlog.

The main purpose of the automatic configuration of GPG space and
locations is for QA and AMAUAT. For production sites it is better to
create GPG Space and locations from the GUI.

Connects to https://github.com/archivematica/Issues/issues/832