### PR TITLE
configure-gpg: Fix GPG create default locations

### DIFF
--- a/tasks/configure-gpg.yml
+++ b/tasks/configure-gpg.yml
@@ -137,7 +137,7 @@
           purpose: "AS"
           relative_path: "{{ archivematica_src_configure_gpg.aipstore_path | regex_replace('^\\/', '') }}"
           description: "{{ archivematica_src_configure_gpg.aipstore_description }}"
-          default: "false"
+          default: false
           space: "/api/v2/space/{{ gpg_list_gpg_spaces_again.json|json_query('objects[*].uuid')|first }}/"
         body_format: json
         status_code: 201
@@ -155,7 +155,7 @@
           purpose: "BL"
           relative_path: "{{ archivematica_src_configure_gpg.aipstore_path | regex_replace('^\\/', '') }}"
           description: "{{ archivematica_src_configure_gpg.aipstore_description }}"
-          default: "false"
+          default: false
           space: "/api/v2/space/{{ gpg_list_gpg_spaces_again.json|json_query('objects[*].uuid')|first }}/"
         body_format: json
         status_code: 201


### PR DESCRIPTION
This commit fixes the issue that creates the GPG locations as default
locations. The 'default' value is a boolean and it was set as a
string.

Connects to https://github.com/archivematica/Issues/issues/891