### PR TITLE
configure-gpg: Fix GPGBacklog path and description

### DIFF
--- a/tasks/configure-gpg.yml
+++ b/tasks/configure-gpg.yml
@@ -153,8 +153,8 @@
         body:
           pipeline: ["/api/v2/pipeline/{{ gpg_list_pipelines.json|json_query('objects[*].uuid')|first }}/"]
           purpose: "BL"
-          relative_path: "{{ archivematica_src_configure_gpg.aipstore_path | regex_replace('^\\/', '') }}"
-          description: "{{ archivematica_src_configure_gpg.aipstore_description }}"
+          relative_path: "{{ archivematica_src_configure_gpg.backlog_path | regex_replace('^\\/', '') }}"
+          description: "{{ archivematica_src_configure_gpg.backlog_description }}"
           default: false
           space: "/api/v2/space/{{ gpg_list_gpg_spaces_again.json|json_query('objects[*].uuid')|first }}/"
         body_format: json


### PR DESCRIPTION
The GPG Backlog was using the GPG AIPStore path and description.

Connects to https://github.com/archivematica/Issues/issues/891