### PR TITLE
rpm: install common package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -165,7 +165,7 @@
 
 - name: "Install archivematica using packages"
   yum:
-    name: "archivematica-dashboard,archivematica-mcp-server,archivematica-mcp-client"
+    name: "archivematica-common,archivematica-dashboard,archivematica-mcp-server,archivematica-mcp-client"
     state: "latest"
   when:
     - archivematica_src_install_am == "rpm"


### PR DESCRIPTION
The first time the role runs, archivematica-common gets installed
due to being a dependency for other packages. Listing it explicityly
allows for the package to be updated on subsequent runs