### PR TITLE
remove nodejs role dependency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,17 +4,12 @@ galaxy_info:
   description: An ansible role for installing Archivematica from source.
   company: Artefactual Systems
   license: AGPLv3
-  min_ansible_version: 2.3
+  min_ansible_version: 2.7
   platforms:
   - name: EL
     versions:
     - 7
   - name: Ubuntu
     versions:
-    - trusty
     - xenial
-
-dependencies:
-- role: geerlingguy.nodejs
-  version: 4.1.1
-  nodejs_version: 8.x
+    - bionic

--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -54,7 +54,7 @@
 - name: "Install front-end dependencies"
   become: "yes"
   become_user: "archivematica"
-  command: npm install
+  command: "{{ npm_path }}/npm install"
   args:
     chdir: "{{ item }}"
   with_items:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,3 +6,4 @@ ansible_deps:
   - "python-mysqldb" # Required for mysql_db module
   - "sqlite3"        # Required for am-configure and fixity
 ca_custom_bundle: "/etc/ssl/certs/ca-certificates.crt"
+npm_path: "/usr/bin/npm"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -7,3 +7,4 @@ ansible_deps:
   - "sqlite"       # Required for am-configure and fixity
   - "p7zip-plugins" 
 ca_custom_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
+npm_path: "/opt/rh/rh-nodejs8/root/bin/"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -6,5 +6,7 @@ ansible_deps:
   - "MySQL-python" # Required for mysql_db module
   - "sqlite"       # Required for am-configure and fixity
   - "p7zip-plugins" 
+  - "centos-release-scl-rh" # Required for rh-nodejs8
+  - "rh-nodejs8-npm"
 ca_custom_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
 npm_path: "/opt/rh/rh-nodejs8/root/bin/"


### PR DESCRIPTION
nodejs 8 is already provided by ubuntu, and also provided in a [software collection ](https://www.softwarecollections.org/en/scls/rhscl/rh-nodejs8/)for redhat/centos.

This removes the role dependency, and for trusty, it can be added to the singlenode playbook, and apply it conditionally

This is a work in progress

TODO:
 - Update deploy-pub to handle trusty case
 - Install centos-release-scl-rh on centos/rhel
 - Add npm/rh-nodejs8-npm to osdeps