### PR TITLE
Allow for multiple mcp-c deployment

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ archivematica_src_install_automationtools: "no"
 archivematica_src_install_acceptance_tests: "no"
 archivematica_src_install_fixity: "no"
 archivematica_src_search_enabled: "yes"
+archivematica_src_am_mcpclient_instances: 1
 
 #Components to configure
 archivematica_src_configure_dashboard: "no"

--- a/tasks/pipeline-environment.yml
+++ b/tasks/pipeline-environment.yml
@@ -41,10 +41,53 @@
   with_items:
     - src: "etc/sysconfig/archivematica-mcp-server.j2"
       dest: "{{ systemd_environment_path }}/archivematica-mcp-server"
-    - src: "etc/sysconfig/archivematica-mcp-client.j2"
-      dest: "{{ systemd_environment_path }}/archivematica-mcp-client"
     - src: "etc/sysconfig/archivematica-dashboard.j2"
       dest: "{{ systemd_environment_path }}/archivematica-dashboard"
+
+- name: "Create config files (single mcp)"
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    backup: "yes"
+  with_items:
+    - src: "etc/sysconfig/archivematica-mcp-client.j2"
+      dest: "{{ systemd_environment_path }}/archivematica-mcp-client"
+    - src: "etc/systemd/system/archivematica-mcp-client.service.j2"
+      dest: "/etc/systemd/system/archivematica-mcp-client.service"
+  when: "archivematica_src_am_mcpclient_instances == 1"
+
+
+- name: "Configure mcp-clients (multiple)"
+  block:
+
+  - name: "Remove mcp-client single configuration files"
+    file:
+      path: "{{ item }}"
+      state: absent
+    with_items:
+      - /etc/sysconfig/archivematica-mcp-client
+      - /etc/systemd/system/archivematica-mcp-client.service
+
+  - name: "Create extra systemd mcpclient services"
+    template:
+      src: "etc/systemd/system/archivematica-mcp-client.service.j2"
+      dest: "/etc/systemd/system/archivematica-mcp-client-{{ '%1x' | format(item) }}.service"
+    loop: "{{ range(1, archivematica_src_am_mcpclient_instances|int  + 1, 1)|list }}"
+
+  - name: "Configure extra mcp-clients"
+    template:
+      src: "etc/sysconfig/archivematica-mcp-client.j2"
+      dest: "{{ systemd_environment_path }}/{{ 'archivematica-mcp-client-%1x' | format(item) }}"
+    loop: "{{ range(1, archivematica_src_am_mcpclient_instances|int  + 1, 1)|list }}"
+
+  - name: "Update prometheus port"
+    lineinfile:
+      path: "{{ systemd_environment_path }}/{{ 'archivematica-mcp-client-%1x' | format(item) }}"
+      regexp: "^ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_PROMETHEUS_BIND_PORT="
+      line: "ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_PROMETHEUS_BIND_PORT=911{{ '%1x' | format(item) }}"
+    loop: "{{ range(1, archivematica_src_am_mcpclient_instances|int  + 1, 1)|list }}"
+
+  when: archivematica_src_am_mcpclient_instances > 1
 
 
 #
@@ -110,8 +153,6 @@
   with_items:
     - src: "etc/systemd/system/archivematica-mcp-server.service.j2"
       dest: "/etc/systemd/system/archivematica-mcp-server.service"
-    - src: "etc/systemd/system/archivematica-mcp-client.service.j2"
-      dest: "/etc/systemd/system/archivematica-mcp-client.service"
     - src: "etc/systemd/system/archivematica-dashboard.service.j2"
       dest: "/etc/systemd/system/archivematica-dashboard.service"
 
@@ -128,8 +169,30 @@
     daemon_reload: "yes"
   with_items:
     - "archivematica-mcp-server"
-    - "archivematica-mcp-client"
     - "archivematica-dashboard"
     - "fits-nailgun"
   when:
     - ansible_service_mgr == "systemd"
+
+- name: "Enable mcpclient service (single)"
+  systemd:
+    name: "archivematica-mcp-client"
+    state: "restarted"
+    enabled: "yes"
+    daemon_reload: "yes"
+  when:
+    - ansible_service_mgr == "systemd"
+    - archivematica_src_am_mcpclient_instances ==  1
+
+- name: "Enable mcpclient service (multiple)"
+  systemd:
+    name: "{{ 'archivematica-mcp-client-%1x' | format(item) }}"
+    state: "restarted"
+    enabled: "yes"
+    daemon_reload: "yes"
+  loop: "{{ range(1, archivematica_src_am_mcpclient_instances|int  + 1, 1)|list }}"
+  when:
+    - ansible_service_mgr == "systemd"
+    - archivematica_src_am_mcpclient_instances > 1
+
+

--- a/templates/etc/systemd/system/archivematica-mcp-client.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-client.service.j2
@@ -8,7 +8,11 @@ After=syslog.target network.target
 Type=simple
 User=archivematica
 Group=archivematica
+{% if archivematica_src_am_mcpclient_instances == 1 %}
 EnvironmentFile=-{{ systemd_environment_path }}/archivematica-mcp-client
+{% else %}
+EnvironmentFile=-{{ systemd_environment_path }}/archivematica-mcp-client-{{ '%1x' | format(item) }}
+{% endif %}
 {% if archivematica_src_syslog_enabled|bool %}
 StandardOutput=syslog
 StandardError=syslog


### PR DESCRIPTION
When archivematica_src_am_mcpclient_instances is greater than 1,
mcpclients will be deployed using the following naming schema:

  - archivematica-mcp-client-1
  - archivematica-mcp-client-2
  - archivematica-mcp-client-XX

And the default archivematica-mcp-client service will be removed.