### PR TITLE
Get Storageservice API key from database

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -22,6 +22,20 @@
 - set_fact: archivematica_src_configure_ss_api_key={{ 999999999999999999999 | random | to_uuid | hash('md5') }}
   when: "archivematica_src_configure_ss_api_key is undefined and archivematica_src_configure_ss|bool"
 
+- name: "Get API Key"
+  become: "yes"
+  command: >
+    mysql --user="{{ archivematica_src_ss_db_user }}"
+          --password="{{ archivematica_src_ss_db_password }}"
+          --host="{{ archivematica_src_ss_db_host }}"
+          "{{ archivematica_src_ss_db_name }}"
+          --batch --skip-column-names
+          --execute="select `key` from tastypie_apikey where id in (select id from auth_user where username = '{{ archivematica_src_configure_ss_user }}');"
+  register: archivematica_src_configure_ss_api_key_temp
+  when: "archivematica_src_configure_ss_api_key is undefined and archivematica_src_configure_dashboard|bool"
+- set_fact: archivematica_src_configure_ss_api_key="{{ archivematica_src_configure_ss_api_key_temp.stdout }}"
+  when: "archivematica_src_configure_dashboard|bool and archivematica_src_configure_ss_api_key_temp is defined"
+
 - name: "Check for default SS user"
   become: "yes"
   shell: echo 'select username from auth_user where (id=1 and last_login is NULL and first_name="" and last_name="" and email="x@x.com" and username="test");'  | {{ archivematica_src_ss_virtualenv }}/bin/python manage.py dbshell

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -32,9 +32,9 @@
           --batch --skip-column-names
           --execute="select `key` from tastypie_apikey where id in (select id from auth_user where username = '{{ archivematica_src_configure_ss_user }}');"
   register: archivematica_src_configure_ss_api_key_temp
-  when: "archivematica_src_configure_ss_api_key is undefined and archivematica_src_configure_dashboard|bool"
+  when: "archivematica_src_configure_dashboard|bool and archivematica_src_configure_ss_api_key is undefined"
 - set_fact: archivematica_src_configure_ss_api_key="{{ archivematica_src_configure_ss_api_key_temp.stdout }}"
-  when: "archivematica_src_configure_dashboard|bool and archivematica_src_configure_ss_api_key_temp is defined"
+  when: "archivematica_src_configure_dashboard|bool and archivematica_src_configure_ss_api_key_temp.stdout is defined"
 
 - name: "Check for default SS user"
   become: "yes"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -22,17 +22,20 @@
 - set_fact: archivematica_src_configure_ss_api_key={{ 999999999999999999999 | random | to_uuid | hash('md5') }}
   when: "archivematica_src_configure_ss_api_key is undefined and archivematica_src_configure_ss|bool"
 
-- name: "Get API Key"
-  become: "yes"
-  command: >
-    mysql --user="{{ archivematica_src_ss_db_user }}"
-          --password="{{ archivematica_src_ss_db_password }}"
-          --host="{{ archivematica_src_ss_db_host }}"
-          "{{ archivematica_src_ss_db_name }}"
-          --batch --skip-column-names
-          --execute="select `key` from tastypie_apikey where id in (select id from auth_user where username = '{{ archivematica_src_configure_ss_user }}');"
+- name: "Get SS API Key"
+  shell: >
+    echo "select key from tastypie_apikey where id in (select id from auth_user where username = '{{ archivematica_src_configure_ss_user }}');"
+    | {{ archivematica_src_ss_virtualenv }}/bin/python manage.py dbshell
+  args:
+    chdir: "{{ archivematica_src_ss_app }}"
+    executable: /bin/bash
+  environment: "{{ archivematica_src_ss_environment }}"
+  delegate_to: "{{ archivematica_src_configure_ss_url|urlsplit('hostname') }}"
+  become: yes
+  remote_user: "{{ archivematica_src_configure_ss_ssh_user | default('artefactual') }}"
   register: archivematica_src_configure_ss_api_key_temp
   when: "archivematica_src_configure_dashboard|bool and archivematica_src_configure_ss_api_key is undefined"
+
 - set_fact: archivematica_src_configure_ss_api_key="{{ archivematica_src_configure_ss_api_key_temp.stdout }}"
   when: "archivematica_src_configure_dashboard|bool and archivematica_src_configure_ss_api_key_temp.stdout is defined"
 


### PR DESCRIPTION
When installing only the Dashboard component the archivematica_src_configure_ss_api_key will not be configured and is needed to register the Dashboard to the Storage Service.

This PR will add the "Get API Key" part to gather the api key from the storage user archivematica_src_configure_ss_user and put the output in archivematica_src_configure_ss_api_key.

I've decided to fill in archivematica_src_configure_ss_api_key with the correct values instead of changing the rest of the script to archivematica_src_configure_ss_api_key.stdout. This can be done later to remove the set_fact.

Connects to https://github.com/artefactual-labs/ansible-archivematica-src/issues/280