### PR TITLE
configure: Improve the use of delegate_to

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -30,7 +30,7 @@
     chdir: "{{ archivematica_src_ss_app }}"
     executable: /bin/bash
   environment: "{{ archivematica_src_ss_environment }}"
-  delegate_to: "{{ archivematica_src_configure_ss_url|urlsplit('hostname') }}"
+  delegate_to: "{{ archivematica_src_configure_ss_inventory_hostname | default(archivematica_src_configure_ss_url|urlsplit('hostname')) }}"
   become: yes
   remote_user: "{{ archivematica_src_configure_ss_ssh_user | default('artefactual') }}"
   register: archivematica_src_configure_ss_api_key_temp
@@ -201,7 +201,7 @@
     home: "/home/archivematica"
     createhome: True
     shell: "/bin/bash"
-  delegate_to: "{{ archivematica_src_configure_dashboardsettings['url']|urlsplit('hostname') }}"
+  delegate_to: "{{ archivematica_src_configure_atom_inventory_hostname | default(archivematica_src_configure_dashboardsettings['url']|urlsplit('hostname')) }}"
   remote_user: "{{ archivematica_src_configure_atom_ssh_user | default('artefactual') }}"
   when: archivematica_src_configure_dashboardsettings is defined
 
@@ -210,7 +210,7 @@
     user: "archivematica"
     state: "present"
     key: "{{ ssh_key.stdout }}"
-  delegate_to: "{{ archivematica_src_configure_dashboardsettings['url']|urlsplit('hostname') }}"
+  delegate_to: "{{ archivematica_src_configure_atom_inventory_hostname | default(archivematica_src_configure_dashboardsettings['url']|urlsplit('hostname')) }}"
   remote_user: "{{ archivematica_src_configure_atom_ssh_user | default('artefactual') }}"
   when: archivematica_src_configure_dashboardsettings is defined
 


### PR DESCRIPTION
When getting the hostname from `archivematica_src_configure_ss_url` and
`archivematica_src_configure_dashboardsettings` dictionaries to be used with
the `delegate_to` keywork, it could fail when delegated host has different IP
address or hostname from ansible host than the one used by the pipeline host.
For instance, it is on a private network or different DNS zone.

Adding the new variables `archivematica_src_configure_ss_inventory_hostname`
and `archivematica_src_configure_atom_inventory_hostname` allows to configure
the `delegate_to` destination with other hostname or IP address.

Connects to https://github.com/artefactual-labs/ansible-archivematica-src/issues/280