### PR TITLE
Truncate dbshell output

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -25,7 +25,7 @@
 - name: "Get SS API Key"
   shell: >
     echo "select \`key\` from tastypie_apikey where id in (select id from auth_user where username = '{{ archivematica_src_configure_ss_user }}');"
-    | {{ archivematica_src_ss_virtualenv }}/bin/python manage.py dbshell
+    | {{ archivematica_src_ss_virtualenv }}/bin/python manage.py dbshell | tail -n1
   args:
     chdir: "{{ archivematica_src_ss_app }}"
     executable: /bin/bash

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -41,7 +41,7 @@
 
 - name: "Check for default SS user"
   become: "yes"
-  shell: echo 'select username from auth_user where (id=1 and last_login is NULL and first_name="" and last_name="" and email="x@x.com" and username="test");'  | {{ archivematica_src_ss_virtualenv }}/bin/python manage.py dbshell dbshell | tail -n1
+  shell: echo 'select username from auth_user where (id=1 and last_login is NULL and first_name="" and last_name="" and email="x@x.com" and username="test");'  | {{ archivematica_src_ss_virtualenv }}/bin/python manage.py dbshell | tail -n1
   args:
     chdir: "{{ archivematica_src_ss_app }}"
     executable: /bin/bash

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -41,7 +41,7 @@
 
 - name: "Check for default SS user"
   become: "yes"
-  shell: echo 'select username from auth_user where (id=1 and last_login is NULL and first_name="" and last_name="" and email="x@x.com" and username="test");'  | {{ archivematica_src_ss_virtualenv }}/bin/python manage.py dbshell
+  shell: echo 'select username from auth_user where (id=1 and last_login is NULL and first_name="" and last_name="" and email="x@x.com" and username="test");'  | {{ archivematica_src_ss_virtualenv }}/bin/python manage.py dbshell dbshell | tail -n1
   args:
     chdir: "{{ archivematica_src_ss_app }}"
     executable: /bin/bash

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -66,7 +66,7 @@
 
 - name: "Check for SS user"
   become: "yes"
-  shell: echo 'select username from auth_user where username="{{ archivematica_src_configure_ss_user }}";'  | {{ archivematica_src_ss_virtualenv }}/bin/python manage.py dbshell
+  shell: echo 'select username from auth_user where username="{{ archivematica_src_configure_ss_user }}";'  | {{ archivematica_src_ss_virtualenv }}/bin/python manage.py dbshell | tail -n1
   args:
     chdir: "{{ archivematica_src_ss_app }}"
     executable: /bin/bash


### PR DESCRIPTION
When using 'dbshell' to select information from the database, the output will contain the column name at the first line. By sending the output to 'tail' we can remove the first line and send the correct information to the variable.

This should eventually be solved as an argument to 'dbshell' to manipulate the output.

Connects to https://github.com/artefactual-labs/ansible-archivematica-src/issues/280