### PR TITLE
Configure: Use wantlist on fpdict tasks

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -236,7 +236,7 @@
            "{{ archivematica_src_am_db_name }}"
            --batch --skip-column-names
            --execute="update fpr_fpcommand set enabled={{ item.value.enabled }} where {{ item.value.field_name }}=\"{{ item.key }}\";"
-  loop: "{{ lookup('dict',archivematica_src_configure_fpcommand|default({})) }}"
+  loop: "{{ lookup('dict',archivematica_src_configure_fpcommand|default({}),wantlist=True) }}"
   when: archivematica_src_configure_fpcommand is defined
 #
 - name: "Configure fprule settings"
@@ -247,7 +247,7 @@
            "{{ archivematica_src_am_db_name }}"
            --batch --skip-column-names
            --execute="update fpr_fprule set enabled={{ item.value.enabled }} where {{ item.value.field_name }}=\"{{ item.key }}\";"
-  loop: "{{ lookup('dict',archivematica_src_configure_fprule|default({})) }}"
+  loop: "{{ lookup('dict',archivematica_src_configure_fprule|default({}),wantlist=True) }}"
   when: archivematica_src_configure_fprule is defined
 
 - name: "Configure locations"


### PR DESCRIPTION
The loop keyword always requires a list, and it is known that in single item
lists that lookup will not return a list. Adding wantlist=True to the lookup
invocations allows to use dictionaries with a single item list.

Connects to https://github.com/artefactual-labs/ansible-archivematica-src/issues/290