### PR TITLE
Add initial support for a test CAS server

### DIFF
--- a/tasks/configure-cas.yml
+++ b/tasks/configure-cas.yml
@@ -1,0 +1,28 @@
+---
+
+# Install django cas auth server
+
+- name: "Clone CAS server code"
+  git: 
+    repo: "https://github.com/django-cas-ng/demo-cas-server"
+    dest: "{{ archivematica_src_dir }}/demo-cas-server"
+    version: "master"
+    accept_hostkey: "yes"
+
+- name: "Create virtualenv and install requirements"
+  pip:
+    requirements: "{{ archivematica_src_dir }}/demo-cas-server/requirements.txt"
+    virtualenv: "/usr/share/archivematica/virtualenvs/demo-cas-server"
+    virtualenv_python: python3.6
+
+- name: "Create systemd template"
+  template:
+    src: etc/systemd/system/demo-cas-server.service
+    dest: "/etc/systemd/system/demo-cas-server.service"
+
+- name: "Start/Restart CAS server"
+  service:
+    name: "demo-cas-server"
+    state: "restarted"
+    enabled: "yes"
+    daemon_reload: "yes"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -266,6 +266,15 @@
   tags:
     - "amsrc-fixity"
   when: "archivematica_src_install_fixity|bool"
+ 
+# Configure local CAS server
+#
+
+- include: "configure-cas.yml"
+  tags:
+    - "amsrc-configure-cas"
+  when:
+    - "archivematica_src_install_cas is defined"
 
 #
 # Configure pipeline and SS
@@ -275,6 +284,7 @@
   tags:
     - "amsrc-configure"
   when: "archivematica_src_configure_ss|bool or archivematica_src_configure_dashboard|bool"
+
 
 #
 # Configure GPG locations

--- a/templates/etc/systemd/system/demo-cas-server.service
+++ b/templates/etc/systemd/system/demo-cas-server.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Django CAS test server
+
+[Service]
+Restart=on-failure
+User=archivematica
+Group=archivematica
+WorkingDirectory=/opt/archivematica/demo-cas-server/
+ExecStart=/usr/share/archivematica/virtualenvs/demo-cas-server/bin/python3 manage.py runserver 8100
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
We are using https://github.com/django-cas-ng/demo-cas-server

By default, settings are hardcoded, so it will listen on port 8100 of
localhost.

In order to install it, ansible variable archivematica_src_install_cas
needs to be se to true