### PR TITLE
Allow to run services with custom user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,11 @@ archivematica_src_install_fixity: "no"
 archivematica_src_search_enabled: "yes"
 archivematica_src_am_mcpclient_instances: 1
 
+# System Users
+archivematica_src_am_system_user: "archivematica"
+archivematica_src_am_system_group: "archivematica"
+archivematica_src_ss_system_user: "archivematica"
+archivematica_src_ss_system_group: "archivematica"
 #Components to configure
 archivematica_src_configure_dashboard: "no"
 archivematica_src_configure_ss: "no"

--- a/tasks/automation-tools.yml
+++ b/tasks/automation-tools.yml
@@ -28,8 +28,8 @@
   file:
     dest: "{{ item }}"
     state: "directory"
-    owner: "archivematica"
-    group: "archivematica"
+    owner: "{{ archivematica_src_am_system_user }}"
+    group: "{{ archivematica_src_am_system_user }}"
   with_items:
     - "/var/log/archivematica/automation-tools"
     - "/var/archivematica/automation-tools"

--- a/tasks/configure-gpg.yml
+++ b/tasks/configure-gpg.yml
@@ -37,7 +37,7 @@
         executable: "/bin/bash"
       register: "gpg_key_already_exist"
       become: "yes"
-      become_user: "archivematica"
+      become_user: "{{ archivematica_src_ss_system_user }}"
       ignore_errors: "yes"
 
     - name: "Create GPG key when doesn't exist"
@@ -63,7 +63,7 @@
           print(key)
       register: "gpg_fingerprint"
       become: "yes"
-      become_user: "archivematica"
+      become_user: "{{ archivematica_src_ss_system_user }}"
       when: gpg_key_already_exist.rc != 0
 
     - name: "Create GPG Space (new key)"
@@ -119,8 +119,8 @@
     - name: "Create directories for GPG locations"
       file:
         path: "{{ item }}"
-        owner: "archivematica"
-        group: "archivematica"
+        owner: "{{ archivematica_src_ss_system_user }}"
+        group: "{{ archivematica_src_ss_system_group }}"
         mode: "0755"
         state: "directory"
       become: "yes"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -152,7 +152,7 @@
 
 - name: "Create ssh key"
   user:
-    name: "archivematica"
+    name: "{{ archivematica_src_am_system_user }}"
     generate_ssh_key: "yes"
     ssh_key_file: ".ssh/id_rsa"
   when: archivematica_src_configure_dashboardsettings is defined
@@ -161,8 +161,8 @@
   lineinfile:
     create: "yes"
     path: "/var/lib/archivematica/.ssh/config"
-    owner: "archivematica"
-    group: "archivematica"
+    owner: "{{ archivematica_src_am_system_user }}"
+    group: "{{ archivematica_src_am_system_group }}"
     mode: "0600"
     line: "StrictHostKeyChecking no"
   when: archivematica_src_configure_dashboardsettings is defined

--- a/tasks/fixity.yml
+++ b/tasks/fixity.yml
@@ -28,8 +28,8 @@
   file:
      path: "{{ archivematica_src_fixity_virtualenv }}"
      state: "directory"
-     owner: "archivematica"
-     group: "archivematica"
+     owner: "{{ archivematica_src_ss_system_user }}"
+     group: "{{ archivematica_src_ss_system_group }}"
      recurse: "yes"
 
 - name: "Create config file"
@@ -37,16 +37,16 @@
      src: "etc/sysconfig/fixity.j2"
      dest: "{{ systemd_environment_path }}/fixity"
      mode: 0640
-     owner: "archivematica"
-     group: "archivematica"
+     owner: "{{ archivematica_src_ss_system_user }}"
+     group: "{{ archivematica_src_ss_system_group }}"
 
 - name: "Create log dir"
   file:
      path: "/var/log/archivematica/fixity/"
      state: "directory"
      mode: 0750
-     owner: "archivematica"
-     group: "archivematica"
+     owner: "{{ archivematica_src_ss_system_user }}"
+     group: "{{ archivematica_src_ss_system_group }}"
 
 - name: "Create fixity script"
   template:
@@ -66,7 +66,7 @@
      hour: "3"
      day: "1"
      month: "*/3"
-     user: "archivematica"
+     user: "{{ archivematica_src_ss_system_user }}"
      cron_file: "fixity"
      state: "present"
 
@@ -76,5 +76,5 @@
      env: yes
      value: "/bin/bash"
      cron_file: "fixity"
-     user: "archivematica"
+     user: "{{ archivematica_src_ss_system_user }}"
      state: "present"

--- a/tasks/pipeline-environment.yml
+++ b/tasks/pipeline-environment.yml
@@ -20,8 +20,8 @@
   file:
     dest: "{{ archivematica_src_shareddir }}"
     state: "directory"
-    owner: "archivematica"
-    group: "archivematica"
+    owner: "{{ archivematica_src_am_system_user }}"
+    group: "{{ archivematica_src_am_system_group }}"
     mode: "0755"
   when: "archivematica_src_reset_shareddir|bool or archivematica_src_reset_am_all|bool"
 

--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -44,8 +44,8 @@
   file:
     dest: "{{ archivematica_src_dir }}"
     state: "directory"
-    owner: "archivematica"
-    group: "archivematica"
+    owner: "{{ archivematica_src_am_system_user }}"
+    group: "{{ archivematica_src_am_system_group }}"
     recurse: "yes"
   with_items:
     - "{{ archivematica_src_dir }}/archivematica/src/dashboard/src/media"
@@ -53,7 +53,7 @@
 
 - name: "Install front-end dependencies"
   become: "yes"
-  become_user: "archivematica"
+  become_user: "{{ archivematica_src_am_system_user }}"
   command: npm install
   args:
     chdir: "{{ item }}"

--- a/tasks/pipeline-osconf.yml
+++ b/tasks/pipeline-osconf.yml
@@ -44,8 +44,8 @@
   file:
     dest: "{{ archivematica_src_shareddir }}"
     state: "directory"
-    owner: "archivematica"
-    group: "archivematica"
+    owner: "{{ archivematica_src_am_system_user }}"
+    group: "{{ archivematica_src_am_system_group }}"
   when: "create_shareddir"
 
 # (this is required because some hardcoding of the shared dir remains in archivematica code)
@@ -77,8 +77,8 @@
   file:
     dest: "{{ item }}"
     state: "directory"
-    owner: "archivematica"
-    group: "archivematica"
+    owner: "{{ archivematica_src_am_system_user }}"
+    group: "{{ archivematica_src_am_system_group }}"
     mode: "g+s"
   with_items:
     - "{{ archivematica_src_dashboard_logdir }}"
@@ -90,7 +90,7 @@
   file:
     dest: "{{ item }}"
     state: "directory"
-    owner: "archivematica"
+    owner: "{{ archivematica_src_am_system_user }}"
     group: "syslog"
     mode: "g+w"
   with_items:
@@ -100,8 +100,8 @@
 - name: "Touch log files"
   file:
     path: "{{ item }}"
-    owner: "archivematica"
-    group: "archivematica"
+    owner: "{{ archivematica_src_am_system_user }}"
+    group: "{{ archivematica_src_am_system_group }}"
     state: "touch"
   with_items:
     - "{{ archivematica_src_dashboard_logdir }}/dashboard.log"

--- a/tasks/ss-db.yml
+++ b/tasks/ss-db.yml
@@ -38,8 +38,8 @@
 - name: "Fix DB permissions"
   file:
     dest: "{{ archivematica_src_ss_environment['SS_DB_NAME'] }}"
-    owner: "archivematica"
-    group: "archivematica"
+    owner: "{{ archivematica_src_ss_system_user }}"
+    group: "{{ archivematica_src_ss_system_group }}"
     mode: "u=rwX,g=rwX,o=rX"
   when: "archivematica_src_ss_environment['SS_DB_URL'] is not defined"
 

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -97,8 +97,8 @@
   file:
     dest: "{{ item }}"
     state: "directory"
-    owner: "archivematica"
-    group: "archivematica"
+    owner: "{{ archivematica_src_ss_system_user }}"
+    group: "{{ archivematica_src_ss_system_group }}"
   with_items:
     - "/var/archivematica/storage-service"
   tags: "amsrc-ss-osconf"
@@ -115,8 +115,8 @@
   file:
     dest: "{{ archivematica_src_ss_logdir }}"
     state: "directory"
-    owner: "archivematica"
-    group: "archivematica"
+    owner: "{{ archivematica_src_ss_system_user }}"
+    group: "{{ archivematica_src_ss_system_group }}"
     mode: "g+s"
   tags: "amsrc-ss-osconf"
   when: "archivematica_src_logging_backward_compatible|bool"
@@ -124,8 +124,8 @@
 - name: "Touch SS log files"
   file:
     path: "{{ archivematica_src_ss_logdir }}/{{ item }}"
-    owner: "archivematica"
-    group: "archivematica"
+    owner: "{{ archivematica_src_ss_system_user }}"
+    group: "{{ archivematica_src_ss_system_group }}"
     state: "touch"
   with_items:
     - "storage_service.log"

--- a/templates/etc/systemd/system/archivematica-dashboard.service.j2
+++ b/templates/etc/systemd/system/archivematica-dashboard.service.j2
@@ -8,8 +8,8 @@ StartLimitBurst=5
 
 [Service]
 PIDFile=/run/archivematica-dashboard_gunicorn.pid
-User=archivematica
-Group=archivematica
+User={{ archivematica_src_am_system_user }}
+Group={{ archivematica_src_am_system_group }}
 EnvironmentFile=-{{ systemd_environment_path }}/archivematica-dashboard
 {% if archivematica_src_syslog_enabled|bool %}
 StandardOutput=syslog

--- a/templates/etc/systemd/system/archivematica-mcp-client.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-client.service.j2
@@ -6,8 +6,8 @@ After=syslog.target network.target
 
 [Service]
 Type=simple
-User=archivematica
-Group=archivematica
+User={{ archivematica_src_am_system_user }}
+Group={{ archivematica_src_am_system_group }}
 {% if archivematica_src_am_mcpclient_instances == 1 %}
 EnvironmentFile=-{{ systemd_environment_path }}/archivematica-mcp-client
 {% else %}

--- a/templates/etc/systemd/system/archivematica-mcp-server.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-server.service.j2
@@ -6,8 +6,8 @@ After=syslog.target network.target mysql.service
 
 [Service]
 Type=simple
-User=archivematica
-Group=archivematica
+User={{ archivematica_src_am_system_user }}
+Group={{ archivematica_src_am_system_group }}
 EnvironmentFile=-{{ systemd_environment_path }}/archivematica-mcp-server
 {% if archivematica_src_syslog_enabled|bool %}
 StandardOutput=syslog

--- a/templates/etc/systemd/system/archivematica-storage-service.service.j2
+++ b/templates/etc/systemd/system/archivematica-storage-service.service.j2
@@ -6,8 +6,8 @@ After=network.target
 
 [Service]
 PIDFile=/run/archivematica-storage-service_gunicorn.pid
-User=archivematica
-Group=archivematica
+User={{ archivematica_src_ss_system_user }}
+Group={{ archivematica_src_ss_system_group }}
 EnvironmentFile=-{{ systemd_environment_path }}/archivematica-storage-service
 {% if archivematica_src_syslog_enabled|bool %}
 StandardOutput=syslog

--- a/templates/etc/systemd/system/fits-nailgun.service.j2
+++ b/templates/etc/systemd/system/fits-nailgun.service.j2
@@ -5,7 +5,7 @@ Description=FITS Nailgun server
 After=syslog.target network.target
 
 [Service]
-User=archivematica
+User={{ archivematica_src_am_system_user }}
 ExecStart=/usr/bin/fits-ngserver.sh /usr/share/maven-repo/com/martiansoftware/nailgun-server/debian/nailgun-server-debian.jar
 Restart=always
 RestartSec=3


### PR DESCRIPTION
In some envs, archivematica needs to run with an user different than
"archivematica"

This pr adds two configuration default to allow so:
  - archivematica_src_am_system_user
  - archivematica_src_am_system_group
  - archivematica_src_ss_system_user
  - archivematica_src_ss_system_group

Connects to https://github.com/artefactual-labs/ansible-archivematica-src/issues/307