### PR TITLE
SS: Define default SS_GUNICORN_WORKERS with MySQL

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,20 @@
       defaults: "{{ _archivematica_src_ss_environment }}"
   tags: "always"
 
+# Append SS_GUNICORN_WORKERS=3 only when SS_GUNICORN_WORKERS
+# is not defined in dictionary and MySQL database
+- name: "Append default SS_GUNICORN_WORKERS when using MySQL"
+  set_fact:
+    "{{ item.name }}": "{{ item.dict|combine({item.key: 3}) }}"
+  with_items:
+    - name: "archivematica_src_ss_environment"
+      dict: "{{ archivematica_src_ss_environment }}"
+      key: "SS_GUNICORN_WORKERS"
+  when:
+    - archivematica_src_ss_environment['SS_DB_URL'] is defined
+    - archivematica_src_ss_environment['SS_GUNICORN_WORKERS'] is not defined
+  tags: "always"
+
 - include: "envs-patch-backward-compatibility.yml"
   tags: "always"
 


### PR DESCRIPTION
When using SS with MySQL database the default SS_GUNICORN_WORKERS is set to 3.

When using sqlite the default value is 1 because it was defined in SS code:

https://github.com/artefactual/archivematica-storage-service/blob/stable/0.16.x/install/storage-service.gunicorn-config.py#L20

Connects to https://github.com/archivematica/Issues/issues/944