### PR TITLE
WIP: basic checks before upgrades

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -181,6 +181,12 @@ archivematica_src_configure_am_whitelist: '""'               # Dashboard API whi
 
 
 #
+# upgrade requirements checks
+#
+check_for_upgrade_requirements: True
+force_completedTransfers_cleanup: False
+
+#
 #  Send logs to syslog
 #
 archivematica_src_syslog_enabled: "false"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,6 +84,15 @@
        archivematica_src_install_am|bool or
        archivematica_src_install_am=='rpm'"
  
+#
+# basic checks before upgrade
+#
+
+- include: upgrade-requirements.yml
+  tags: "check-upgrade-requirements"
+  when: 
+  - "check_for_upgrade_requirements|bool"
+  - "archivematica_src_configure_dashboard|bool"
 
 - name: "Checkout out archivematica-sampledata repository"
   git:

--- a/tasks/upgrade-requirements.yml
+++ b/tasks/upgrade-requirements.yml
@@ -7,14 +7,19 @@
 
 - name: "CompletedTransfers folder has {{ completedTransfersFiles.stdout }} files"
   fail:
-    msg: "Abort!! The {{ archivematica_src_shareddir }}watchedDirectories/SIPCreation/completedTransfers has 
-    {{ completedTransfersFiles.stdout }} files and could cause a large amount of emails after the upgrade. /n
-     Please remove these files before continue or set the variable force_completedTransfers_cleanup: True "
-  when: "completedTransfersFiles.stdout != 0 and not force_completedTransfers_cleanup|bool"
+    msg: 
+    - "Abort!! The {{ archivematica_src_shareddir }}watchedDirectories/SIPCreation/completedTransfers has 
+    {{ completedTransfersFiles.stdout }} files and could cause a large amount of emails after the upgrade."
+    - "Please remove these files before continue or set the variable force_completedTransfers_cleanup: True "
+  when: 
+  - completedTransfersFiles.stdout != "0" 
+  - not force_completedTransfers_cleanup|bool
 
 - name: Cleaning {{ archivematica_src_shareddir }} folder before upgrading
 #  file:
 #    state: absent
 #    path: "{{ archivematica_src_shareddir }}/watchedDirectories/SIPCreation/completedTransfers/"
   shell: "rm -rf {{ archivematica_src_shareddir }}/watchedDirectories/SIPCreation/completedTransfers/*"
-  when: "completedTransfersFiles.stdout != 0 and force_completedTransfers_cleanup|bool"
+  when: 
+  - completedTransfersFiles.stdout != "0" 
+  - force_completedTransfers_cleanup|bool

--- a/tasks/upgrade-requirements.yml
+++ b/tasks/upgrade-requirements.yml
@@ -1,0 +1,20 @@
+---
+# The intention of this task is to check for some basic requirements for upgrading archivematica
+
+- name: "Checking completedTransfers folder for files..."
+  shell: ls {{ archivematica_src_shareddir }}/watchedDirectories/SIPCreation/completedTransfers | wc -l
+  register: completedTransfersFiles
+
+- name: "CompletedTransfers folder has {{ completedTransfersFiles.stdout }} files"
+  fail:
+    msg: "Abort!! The {{ archivematica_src_shareddir }}watchedDirectories/SIPCreation/completedTransfers has 
+    {{ completedTransfersFiles.stdout }} files and could cause a large amount of emails after the upgrade. /n
+     Please remove these files before continue or set the variable force_completedTransfers_cleanup: True "
+  when: "completedTransfersFiles.stdout != 0 and not force_completedTransfers_cleanup|bool"
+
+- name: Cleaning {{ archivematica_src_shareddir }} folder before upgrading
+#  file:
+#    state: absent
+#    path: "{{ archivematica_src_shareddir }}/watchedDirectories/SIPCreation/completedTransfers/"
+  shell: "rm -rf {{ archivematica_src_shareddir }}/watchedDirectories/SIPCreation/completedTransfers/*"
+  when: "completedTransfersFiles.stdout != 0 and force_completedTransfers_cleanup|bool"


### PR DESCRIPTION

This pr will search for files in the completeTransfers folder
before attempting an upgrade to avoid the **"mail-bomb"** problem.

There are two variables that can be added to the playbook:
_check_for_upgrade_requirements: True_ (dafault value)
 - this will load the upgrade-requirements.yml task
_force_completedTransfers_cleanup: False_ (default value)
 - this will force cleanup of the completedTransfers folder