### PR TITLE
nginx: dashboard security patch

### DIFF
--- a/templates/etc/nginx/sites-available/dashboard-ssl.conf.j2
+++ b/templates/etc/nginx/sites-available/dashboard-ssl.conf.j2
@@ -27,7 +27,9 @@ server {
   location / {
     return 301 https://$host$request_uri;
   }
-
+    location ~ ^/administration/accounts/login/.+$ {
+        return 404;
+    }
 }
 
 server {
@@ -65,5 +67,7 @@ server {
     proxy_read_timeout {{ archivematica_src_am_dashboard_nginx_proxy_read_timeout }};
     proxy_pass http://archivematica_dashboard_backend;
   }
-
+    location ~ ^/administration/accounts/login/.+$ {
+        return 404;
+    }
 }

--- a/templates/etc/nginx/sites-available/dashboard.conf.j2
+++ b/templates/etc/nginx/sites-available/dashboard.conf.j2
@@ -27,5 +27,7 @@ server {
     proxy_read_timeout {{ archivematica_src_am_dashboard_nginx_proxy_read_timeout }};
     proxy_pass http://archivematica_dashboard_backend;
   }
-
+    location ~ ^/administration/accounts/login/.+$ {
+        return 404;
+    }
 }


### PR DESCRIPTION
This applies a nginx security patch for the dashboard /administration/accounts/login
redirecting to a 404