### PR TITLE
Document jmespath dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Notes regarding role dependencies:
 
 Please use Ansible 2.3 or newer with this role.
 
+A number of tasks in this role use the `json_query` filter which needs the JMESPath library installed on the Ansible controller. It can be installed as follows:
+
+    pip install jmespath
+
 
 Example Playbooks
 -----------------


### PR DESCRIPTION
It should also be part of stable/1.12.x, stable/1.11.x and stable/1.10.x.

Connects to https://github.com/artefactual-labs/ansible-archivematica-src/issues/313.