### PR TITLE
Set a single virtual environment for all components

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -122,6 +122,9 @@ archivematica_src_ssl_include_acme_chlg_loc: "false"
 # Other components
 #
 
+# Pip version
+archivematica_src_pip_version: "20.3"
+
 # Sample data
 archivematica_src_install_sample_data_timeout: "3600"
 

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -35,7 +35,7 @@
       dest: "/root/get-pip.py"
 
   - name: "Install pip with get-pip.py"
-    command: "python get-pip.py"
+    command: "python get-pip.py pip=={{ archivematica_src_pip_version }}"
     args:
       chdir: "/root/"
 

--- a/tasks/pipeline-pip-deps.yml
+++ b/tasks/pipeline-pip-deps.yml
@@ -9,40 +9,12 @@
     - "archivematica-mcp-client"
     - "archivematica-mcp-server"
 
-- name: "virtualenv | Set `virtualenvs` variable"
-  set_fact:
-    virtualenvs:
-      - name: "Archivematica MCPServer"
-        path: "{{ archivematica_src_am_mcpserver_virtualenv }}"
-        requirements_dir:
-          - "{{ archivematica_src_dir }}/archivematica/src/archivematicaCommon"
-          - "{{ archivematica_src_dir }}/archivematica/src/MCPServer"
-          - "{{ archivematica_src_dir }}/archivematica/src/dashboard/src"
-      - name: "Archivematica MCPClient"
-        path: "{{ archivematica_src_am_mcpclient_virtualenv }}"
-        requirements_dir:
-          - "{{ archivematica_src_dir }}/archivematica/src/archivematicaCommon"
-          - "{{ archivematica_src_dir }}/archivematica/src/MCPClient"
-          - "{{ archivematica_src_dir }}/archivematica/src/dashboard/src"
-      - name: "Archivematica Dashboard"
-        path: "{{ archivematica_src_am_dashboard_virtualenv }}"
-        requirements_dir:
-          - "{{ archivematica_src_dir }}/archivematica/src/archivematicaCommon"
-          - "{{ archivematica_src_dir }}/archivematica/src/dashboard/src"
-
-- name: "virtualenv | Create environment and install a recent version of pip"
+- name: "virtualenv | Create environment and install requirements"
   pip:
-    name: "pip"
-    virtualenv: "{{ item.path }}"
-    state: "latest"
-  with_items: "{{ virtualenvs }}"
+    virtualenv: "{{ archivematica_src_am_virtualenv }}"
+    requirements: "{{ archivematica_src_dir }}/archivematica/{{ 'requirements-dev.txt' if is_dev else 'requirements.txt' }}"
 
-- name: "virtualenv | Install requirements"
-  pip:
-    chdir: "{{ item.1 }}"
-    virtualenv: "{{ item.0.path }}"
-    state: "latest"
-    requirements: "{{ 'requirements/test.txt' if is_dev else 'requirements.txt' }}"
-  with_subelements:
-    - "{{ virtualenvs }}"
-    - "requirements_dir"
+- name: "virtualenv | Synchronize requirements"
+  command: "{{ archivematica_src_am_virtualenv }}/bin/pip-sync {{ 'requirements-dev.txt' if is_dev else 'requirements.txt' }}"
+  args:
+    chdir: "{{ archivematica_src_dir }}/archivematica"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,14 +1,16 @@
 ---
 ansible_deps: []
 
-archivematica_src_am_dashboard_virtualenv: "/usr/share/archivematica/virtualenvs/archivematica-dashboard"
+archivematica_src_am_virtualenv: "/usr/share/archivematica/virtualenvs/archivematica"
+
+archivematica_src_am_dashboard_virtualenv: "{{ archivematica_src_am_virtualenv }}"
 archivematica_src_am_dashboard_app: "/usr/share/archivematica/dashboard"
 archivematica_src_am_dashboard_gunicorn_config: "/etc/archivematica/dashboard.gunicorn-config.py"
 
-archivematica_src_am_mcpserver_virtualenv: "/usr/share/archivematica/virtualenvs/archivematica-mcp-server"
+archivematica_src_am_mcpserver_virtualenv: "{{ archivematica_src_am_virtualenv }}"
 archivematica_src_am_mcpserver_app: "/usr/lib/archivematica/MCPServer"
 
-archivematica_src_am_mcpclient_virtualenv: "/usr/share/archivematica/virtualenvs/archivematica-mcp-client"
+archivematica_src_am_mcpclient_virtualenv: "{{ archivematica_src_am_virtualenv }}"
 archivematica_src_am_mcpclient_app: "/usr/lib/archivematica/MCPClient"
 
 archivematica_src_am_common_app: "/usr/lib/archivematica/archivematicaCommon"


### PR DESCRIPTION
This sets a single virtual environment for the MCPServer, MCPClient
and dashboard.

This should be merged after https://github.com/artefactual/archivematica/pull/1655

Connected to https://github.com/artefactual/archivematica/issues/573