### PR TITLE
Run compilemessages in Dashboard and Storage Service

### DIFF
--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -71,3 +71,15 @@
     pythonpath: "{{ archivematica_src_am_common_app }}"
     virtualenv: "{{ archivematica_src_am_dashboard_virtualenv }}"
   environment: "{{ archivematica_src_am_dashboard_environment }}"
+
+#
+# compilemessages
+#
+
+- name: "Compile gettext po files (compilemessages)"
+  django_manage:
+    command: "compilemessages"
+    app_path: "{{ archivematica_src_am_dashboard_app }}"
+    pythonpath: "{{ archivematica_src_am_common_app }}"
+    virtualenv: "{{ archivematica_src_am_dashboard_virtualenv }}"
+  environment: "{{ archivematica_src_am_dashboard_environment }}"

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -205,6 +205,14 @@
   environment: "{{ archivematica_src_ss_environment }}"
   tags: ["amsrc-ss-code", "amsrc-ss-code-collectstatic"]
 
+- name: "Run SS django compilemessages"
+  django_manage:
+    command: "compilemessages"
+    app_path: "{{ archivematica_src_ss_app }}"
+    virtualenv: "{{ archivematica_src_ss_virtualenv }}"
+  environment: "{{ archivematica_src_ss_environment }}"
+  tags: ["amsrc-ss-code", "amsrc-ss-code-compilemessages"]
+
 - name: "Copy gunicorn configuration file"
   copy:
     src: "{{ archivematica_src_dir }}/archivematica-storage-service/install/storage-service.gunicorn-config.py"


### PR DESCRIPTION
See https://github.com/archivematica/Issues/issues/984 for more details.

It only takes a couple of seconds to run.
When tested, the following files should be present:

```
/opt/archivematica/archivematica-storage-service/storage_service/locale/en/LC_MESSAGES/django.mo
/opt/archivematica/archivematica-storage-service/storage_service/locale/en/LC_MESSAGES/djangojs.mo
/opt/archivematica/archivematica-storage-service/storage_service/locale/es/LC_MESSAGES/django.mo
/opt/archivematica/archivematica-storage-service/storage_service/locale/es/LC_MESSAGES/djangojs.mo
/opt/archivematica/archivematica-storage-service/storage_service/locale/fr/LC_MESSAGES/django.mo
/opt/archivematica/archivematica-storage-service/storage_service/locale/fr/LC_MESSAGES/djangojs.mo
/opt/archivematica/archivematica-storage-service/storage_service/locale/ja/LC_MESSAGES/django.mo
/opt/archivematica/archivematica-storage-service/storage_service/locale/pt/LC_MESSAGES/django.mo
/opt/archivematica/archivematica-storage-service/storage_service/locale/pt/LC_MESSAGES/djangojs.mo
/opt/archivematica/archivematica-storage-service/storage_service/locale/pt_BR/LC_MESSAGES/django.mo
/opt/archivematica/archivematica-storage-service/storage_service/locale/pt_BR/LC_MESSAGES/djangojs.mo
/opt/archivematica/archivematica-storage-service/storage_service/locale/sv/LC_MESSAGES/django.mo
/opt/archivematica/archivematica-storage-service/storage_service/locale/sv/LC_MESSAGES/djangojs.mo
/opt/archivematica/archivematica/src/dashboard/src/locale/en/LC_MESSAGES/django.mo
/opt/archivematica/archivematica/src/dashboard/src/locale/en/LC_MESSAGES/djangojs.mo
/opt/archivematica/archivematica/src/dashboard/src/locale/es/LC_MESSAGES/django.mo
/opt/archivematica/archivematica/src/dashboard/src/locale/es/LC_MESSAGES/djangojs.mo
/opt/archivematica/archivematica/src/dashboard/src/locale/fr/LC_MESSAGES/django.mo
/opt/archivematica/archivematica/src/dashboard/src/locale/fr/LC_MESSAGES/djangojs.mo
/opt/archivematica/archivematica/src/dashboard/src/locale/ja/LC_MESSAGES/django.mo
/opt/archivematica/archivematica/src/dashboard/src/locale/ja/LC_MESSAGES/djangojs.mo
/opt/archivematica/archivematica/src/dashboard/src/locale/pt/LC_MESSAGES/django.mo
/opt/archivematica/archivematica/src/dashboard/src/locale/pt/LC_MESSAGES/djangojs.mo
/opt/archivematica/archivematica/src/dashboard/src/locale/pt_BR/LC_MESSAGES/django.mo
/opt/archivematica/archivematica/src/dashboard/src/locale/pt_BR/LC_MESSAGES/djangojs.mo
/opt/archivematica/archivematica/src/dashboard/src/locale/sv/LC_MESSAGES/django.mo
/opt/archivematica/archivematica/src/dashboard/src/locale/sv/LC_MESSAGES/djangojs.mo

```

As a result, Dashboard and Storage Service messages should appear in the corresponding language. Language preference is changed under Administration &raquo; Language.

Reminder: also needed in qa/1.x.