### PR TITLE
Use py27-compatible pip

### DIFF
--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -32,6 +32,7 @@
   - name: "Download get-pip.py"
     get_url:
       url: "https://bootstrap.pypa.io/2.7/get-pip.py"
+      force: "yes"
       dest: "/root/get-pip.py"
 
   - name: "Install pip with get-pip.py"

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -31,7 +31,7 @@
 
   - name: "Download get-pip.py"
     get_url:
-      url: "https://bootstrap.pypa.io/get-pip.py"
+      url: "https://bootstrap.pypa.io/2.7/get-pip.py"
       dest: "/root/get-pip.py"
 
   - name: "Install pip with get-pip.py"


### PR DESCRIPTION
Connects to https://github.com/archivematica/Issues/issues/1344.

Must be cherry-picked onto previous release branches.