### PR TITLE
Allow complete deployment when not using configure option

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -129,7 +129,7 @@
   when:
     - archivematica_src_install_ss == "rpm"
 
-- name: "Configure storage service"
+- name: "Complete storage service deployment"
   block:
   - include: "ss-db.yml"
     tags:
@@ -143,7 +143,7 @@
     tags:
       - "amsrc-ss"
       - "amsrc-ss-websrv"
-  when: "archivematica_src_configure_ss|bool"
+  when: "archivematica_src_install_ss|bool"
 
 
 #
@@ -194,7 +194,7 @@
   when:
     - archivematica_src_install_am == "rpm"
 
-- name: "Configure AM environment"
+- name: "Complete AM deployment"
   block:
   - include: "pipeline-dbconf.yml"
     tags:
@@ -216,7 +216,7 @@
       - "amsrc-pipeline"
       - "amsrc-pipeline-websrv"
 
-  when: "archivematica_src_configure_dashboard|bool"
+  when: "archivematica_src_install_am|bool"
 
 
 #


### PR DESCRIPTION
Fix an issue that prevents a complete deployment when the
archivematica_src_configure_dashboard and/or
archivematica_src_configure_ss vars are set to "no"

Fixes https://github.com/archivematica/Issues/issues/1422