### PR TITLE
Update new py27 get-pip URL

### DIFF
--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -31,7 +31,7 @@
 
   - name: "Download get-pip.py"
     get_url:
-      url: "https://bootstrap.pypa.io/2.7/get-pip.py"
+      url: "https://bootstrap.pypa.io/pip/2.7/get-pip.py"
       force: "yes"
       dest: "/root/get-pip.py"
 


### PR DESCRIPTION
The URL for the pip installation has changed which results in errors when running the ansible installation of this version. 
This PR will update the pip installation URL and thus fix that problem.

Connects to https://github.com/archivematica/Issues/issues/1344.