### PR TITLE
Use Python 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This document describes important changes in this role.
 
 Most recent changes first:
 
+- Variables `archivematica_src_pip_version`,
+  `archivematica_src_setuptools_version` and `archivematica_src_wheel_version`
+  are abandoned since we don't need them in the Python 3 environment.
+
 - Variables `archivematica_src_install_devtools` and
   `archivematica_src_devtools_version` are abandoned since Archivematica v1.13
   deprecated the archivematica-devtools repository. Users should rely on

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -128,9 +128,6 @@ archivematica_src_ssl_include_acme_chlg_loc: "false"
 #
 
 # Pip version
-archivematica_src_pip_version: "20.3"
-archivematica_src_setuptools_version: "44.1.1"
-archivematica_src_wheel_version: "0.35.1"
 archivematica_src_pip_tools_version: "5.5.0"
 
 # Sample data

--- a/tasks/acceptance-tests.yml
+++ b/tasks/acceptance-tests.yml
@@ -25,7 +25,8 @@
     chdir: "{{ archivematica_src_dir }}/archivematica-acceptance-tests"
     requirements: "requirements.txt"
     virtualenv: "/usr/share/archivematica/virtualenvs/archivematica-acceptance-tests"
-    virtualenv_python: "python3"
+    virtualenv_command: "{{ archivematica_src_virtualenv }}"
+    virtualenv_python: "{{ archivematica_src_virtualenv_python }}"
     state: latest
 
 #

--- a/tasks/automation-tools.yml
+++ b/tasks/automation-tools.yml
@@ -14,6 +14,8 @@
     chdir: "{{ archivematica_src_dir }}/automation-tools"
     requirements: "requirements.txt"
     virtualenv: "/usr/share/archivematica/virtualenvs/automation-tools"
+    virtualenv_command: "{{ archivematica_src_virtualenv }}"
+    virtualenv_python: "{{ archivematica_src_virtualenv_python }}"
     state: latest
 
 - name: "symlink automation-tools source to /usr/lib/archivematica"

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -29,20 +29,26 @@
         - "python2-pip"
       state: "absent"
 
+  - name: "Ensure Python 3 is installed"
+    package:
+      name: "{{ archivematica_src_python_packages }}"
+      state: "present"
+
   - name: "Download get-pip.py"
     get_url:
-      url: "https://bootstrap.pypa.io/pip/2.7/get-pip.py"
+      url: "https://bootstrap.pypa.io/pip/get-pip.py"
       force: "yes"
       dest: "/root/get-pip.py"
 
   - name: "Install pip with get-pip.py"
-    command: "python get-pip.py pip=={{ archivematica_src_pip_version }} setuptools=={{ archivematica_src_setuptools_version }} wheel=={{ archivematica_src_wheel_version }}"
+    command: "{{ archivematica_src_virtualenv_python }} get-pip.py"
     args:
       chdir: "/root/"
 
   - name: "Install virtualenv with pip"
     pip:
       name: "virtualenv"
+      executable: "{{ archivematica_src_pip }}"
       state: "latest"
 
   #

--- a/tasks/fixity.yml
+++ b/tasks/fixity.yml
@@ -15,6 +15,8 @@
     chdir: "{{ archivematica_src_dir }}/fixity"
     requirements: "requirements.txt"
     virtualenv: "{{ archivematica_src_fixity_virtualenv }}"
+    virtualenv_command: "{{ archivematica_src_virtualenv }}"
+    virtualenv_python: "{{ archivematica_src_virtualenv_python }}"
     state: "latest"
 
 - name: "Run setup.py"

--- a/tasks/pipeline-pip-deps.yml
+++ b/tasks/pipeline-pip-deps.yml
@@ -12,9 +12,14 @@
 - name: "Create virtualenv and install pip-tools"
   pip:
     virtualenv: "{{ archivematica_src_am_virtualenv }}"
+    virtualenv_command: "{{ archivematica_src_virtualenv }}"
+    virtualenv_python: "{{ archivematica_src_virtualenv_python }}"
     name: "pip-tools=={{ archivematica_src_pip_tools_version }}"
 
 - name: "Synchronize requirements"
-  command: "{{ archivematica_src_am_virtualenv }}/bin/pip-sync {{ 'requirements-dev.txt' if is_dev else 'requirements.txt' }}"
+  command: "{{ archivematica_src_am_virtualenv }}/bin/pip-sync {{ 'requirements-dev-py3.txt' if is_dev else 'requirements-py3.txt' }}"
   args:
     chdir: "{{ archivematica_src_dir }}/archivematica"
+  environment:
+    LC_ALL: "en_US.utf8"
+    LANG: "en_US.utf8"

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -59,13 +59,18 @@
 - name: "Create virtualenv and install pip-tools"
   pip:
     virtualenv: "{{ archivematica_src_ss_virtualenv }}"
+    virtualenv_command: "{{ archivematica_src_virtualenv }}"
+    virtualenv_python: "{{ archivematica_src_virtualenv_python }}"
     name: "pip-tools=={{ archivematica_src_pip_tools_version }}"
   tags: "amsrc-ss-pydep"
 
 - name: "Synchronize requirements"
-  command: "{{ archivematica_src_ss_virtualenv }}/bin/pip-sync {{ 'local.txt' if is_dev else 'production.txt' }}"
+  command: "{{ archivematica_src_ss_virtualenv }}/bin/pip-sync {{ 'local-py3.txt' if is_dev else 'production-py3.txt' }}"
   args:
     chdir: "{{ archivematica_src_dir }}/archivematica-storage-service/requirements"
+  environment:
+    LC_ALL: "en_US.utf8"
+    LANG: "en_US.utf8"
   tags: "amsrc-ss-pydep"
 
 ###########################################################

--- a/templates/etc/sysconfig/archivematica-mcp-client.j2
+++ b/templates/etc/sysconfig/archivematica-mcp-client.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 PATH={{ archivematica_src_am_mcpclient_virtualenv }}/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
-PYTHONPATH={{ archivematica_src_am_mcpclient_app }}:{{ archivematica_src_am_common_app }}:{{ archivematica_src_am_dashboard_app }}
+PYTHONPATH={{ archivematica_src_am_mcpclient_app }}:{{ archivematica_src_am_mcpclient_modules_app }}:{{ archivematica_src_am_common_app }}:{{ archivematica_src_am_dashboard_app }}
 LANG="en_US.UTF-8"
 LC_ALL="en_US.UTF-8"
 LC_LANG="en_US.UTF-8"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,6 +2,7 @@
 systemd_environment_path: "/etc/default"
 ansible_deps:
   - "python-pycurl"
+  - "python-setuptools"
   - "git"
   - "python-mysqldb" # Required for mysql_db module
   - "sqlite3"        # Required for am-configure and fixity
@@ -13,3 +14,7 @@ archivematica_src_am_fixity_deps:
   - "sqlite3"
   - "moreutils"
   - "mailutils"
+archivematica_src_python_packages:
+  - "python3.6-dev"
+  - "python3.6-distutils"
+  - "python3-setuptools"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,6 +2,7 @@
 systemd_environment_path: "/etc/sysconfig"
 ansible_deps:
   - "epel-release"
+  - "python-setuptools"
   - "git"
   - "MySQL-python"            # Required for mysql_db module
   - "sqlite"                  # Required for am-configure and fixity
@@ -14,3 +15,7 @@ archivematica_src_am_fixity_deps:
   - "sqlite"
   - "moreutils"
   - "mailx"
+archivematica_src_python_packages:
+  - "python36-devel"
+  - "python36-distutils-extra"
+  - "python36-setuptools"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,6 +12,7 @@ archivematica_src_am_mcpserver_app: "/usr/lib/archivematica/MCPServer"
 
 archivematica_src_am_mcpclient_virtualenv: "{{ archivematica_src_am_virtualenv }}"
 archivematica_src_am_mcpclient_app: "/usr/lib/archivematica/MCPClient"
+archivematica_src_am_mcpclient_modules_app: "/usr/lib/archivematica/MCPClient/clientScripts"
 
 archivematica_src_am_common_app: "/usr/lib/archivematica/archivematicaCommon"
 
@@ -21,3 +22,8 @@ archivematica_src_ss_gunicorn_config: "/etc/archivematica/storage-service.gunico
 
 archivematica_src_am_amauat_deps: []
 archivematica_src_am_fixity_deps: []
+
+archivematica_src_virtualenv: "/usr/local/bin/virtualenv"
+archivematica_src_pip: "/usr/local/bin/pip3.6"
+archivematica_src_virtualenv_python: "python3.6"
+archivematica_src_python_packages: []  # Distro specific (see Debian.yml and RedHat.yml).


### PR DESCRIPTION
It changes the role so Python 3.6 is installed, but it does not attempt to make it the default globally, but makes it the default in our virtual environments.

These are the changes that were required:
* Apply new PYTHONPATH required by MCPClient (clientScripts)
* Install Python 3.6
* Update get-pip URL
* Create virtualenv using pip3.6 and python3.6 (Archivematica's shebang is now `python`)
* Use Archivematica py3-specific requirements files (e.g. requirements-py3.txt instead of requirements.txt)
* Set `en_US.utf8` when using pip-tools (will not be needed in Py 3.7+)
* Remove vars `archivematica_src_pip_version`, `archivematica_src_setuptools_version` and `archivematica_src_wheel_version`

Connects to https://github.com/archivematica/Issues/issues/1317.