### PR TITLE
Destroy virtualenv during py2to3 upgrades

### DIFF
--- a/tasks/pipeline-pip-deps.yml
+++ b/tasks/pipeline-pip-deps.yml
@@ -1,13 +1,18 @@
 ---
-# this task is needed to avoid problems when upgrading python package
-- name: "Remove old virtualenv default dirs"
-  file:
-    state: absent
-    path: "/usr/share/python/{{ item }}/"
-  with_items:
-    - "archivematica-dashboard"
-    - "archivematica-mcp-client"
-    - "archivematica-mcp-server"
+
+- name: "Destroy virtualenv if it's still using Python 2"
+  block:
+    - name: "Capture current Python version"
+      command: |-
+        {{ archivematica_src_am_virtualenv }}/bin/python -c
+          'import sys; sys.stdout.write("{}".format(sys.version_info[0])); sys.stdout.flush();'
+      ignore_errors: yes
+      register: "pyver_check"
+    - name: "Destroy Python 2 virtualenv"
+      file:
+        path: "{{ archivematica_src_am_virtualenv }}"
+        state: "absent"
+      when: "pyver_check.rc == 0 and pyver_check.stdout == '2'"
 
 - name: "Create virtualenv and install pip-tools"
   pip:

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -50,11 +50,19 @@
 #   2- Python dependencies (pip packages)
 ###########################################################
 
-# this task is needed to avoid problems when upgrading python package
-- name: "Remove old SS virtualenv default dir"
-  file:
-    state: absent
-    path: "/usr/share/python/archivematica-storage-service/"
+- name: "Destroy virtualenv if it's still using Python 2"
+  block:
+    - name: "Capture current Python version"
+      command: |-
+        {{ archivematica_src_ss_virtualenv }}/bin/python -c
+          'import sys; sys.stdout.write("{}".format(sys.version_info[0])); sys.stdout.flush();'
+      ignore_errors: yes
+      register: "pyver_check"
+    - name: "Destroy Python 2 virtualenv"
+      file:
+        path: "{{ archivematica_src_ss_virtualenv }}"
+        state: "absent"
+      when: "pyver_check.rc == 0 and pyver_check.stdout == '2'"
 
 - name: "Create virtualenv and install pip-tools"
   pip:


### PR DESCRIPTION
This pull request introduces new tasks in the Ansible role to completely remove the Archivematica and Storage Service virtualenv directories when they report to be on Python 2. We do this because the `pip` task will not update the version as I originally thought.

Here's an example of the new task returning `stdout=3` and `rc=0` when `pyver_check` succeeds and Python reports that its `MAJOR` version is 3. Under these conditions, we proceed to re-use the virtualenv. Otherwise, the virtualenv is destroyed.

```json
{
    "changed": true, 
    "cmd": [
        "/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python", 
        "-c", 
        "import sys; sys.stdout.write(\"{}\".format(sys.version_info[0])); sys.stdout.flush();"
    ], 
    "delta": "0:00:00.038080", 
    "end": "2021-06-10 18:58:05.728210", 
    "invocation": {
        "module_args": {
            "_raw_params": "/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python -c\n  'import sys; sys.stdout.write(\"{}\".format(sys.version_info[0])); sys.stdout.flush();'", 
            "_uses_shell": false, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": null, 
            "removes": null, 
            "stdin": null, 
            "stdin_add_newline": true, 
            "strip_empty_ends": true, 
            "warn": true
        }
    }, 
    "rc": 0, 
    "start": "2021-06-10 18:58:05.690130", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "3", 
    "stdout_lines": [
        "3"
    ]
}
```

Connects to https://github.com/artefactual-labs/ansible-archivematica-src/issues/336.