### PR TITLE
Fixity: Use django dbshell to query SS users email

### DIFF
--- a/templates/bin/fixity-cron
+++ b/templates/bin/fixity-cron
@@ -2,15 +2,27 @@
 
 START_DATE=$(date +%Y%m%d_%H%M)
 REPORTS=/var/log/archivematica/fixity
-EMAILS=$(sqlite3 /var/archivematica/storage-service/storage.db 'select email from auth_user;' | grep -v "x@x")
 
-function run_fixity() {
-echo "Fixity scan starts at $HOSTNAME" | ts '[%Y-%m-%d %H:%M:%S %Z]' > $REPORTS/fixity-$START_DATE.txt
-/usr/local/bin/fixity scanall 2>&1 |ts '[%Y-%m-%d %H:%M:%S %Z]' >> $REPORTS/fixity-$START_DATE.txt
-echo "Fixity scan finished" | ts '[%Y-%m-%d %H:%M:%S %Z]' >> $REPORTS/fixity-$START_DATE.txt
-
+function get_emails(){
+        bash -c " \
+                set -a -e
+                source /etc/default/archivematica-storage-service || \
+                source /etc/sysconfig/archivematica-storage-service \
+                        || (echo 'Environment file not found'; exit 1)
+                cd /usr/lib/archivematica/storage-service
+                echo 'select email from auth_user;' | \
+                        /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python \
+                        manage.py dbshell 2> /dev/null | tail -n+2 | grep -v "x@x"
+";
 }
 
+function run_fixity() {
+	echo "Fixity scan starts at $HOSTNAME" | ts '[%Y-%m-%d %H:%M:%S %Z]' > $REPORTS/fixity-$START_DATE.txt
+	/usr/local/bin/fixity scanall 2>&1 |ts '[%Y-%m-%d %H:%M:%S %Z]' >> $REPORTS/fixity-$START_DATE.txt
+	echo "Fixity scan finished" | ts '[%Y-%m-%d %H:%M:%S %Z]' >> $REPORTS/fixity-$START_DATE.txt
+}
+
+EMAILS=$(get_emails)
 run_fixity 2>&1 > /dev/null
 
 


### PR DESCRIPTION
This allows fixity crontab job to work for SS that use either MySQL or sqlite3 databases.

Connects to #348 

