### PR TITLE
Skip "Get SS API Key" when no SS user exist

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -47,6 +47,7 @@
   when: 
      - "archivematica_src_configure_dashboard|bool or archivematica_src_configure_ss|bool"
      - "archivematica_src_configure_ss_api_key is undefined"
+     - ss_user.stdout != ""
 
 - set_fact: archivematica_src_configure_ss_api_key="{{ archivematica_src_configure_ss_api_key_temp.stdout }}"
   when: 


### PR DESCRIPTION
"Get SS API Key" should only run when "Check for SS user" detects a user.

Due to "Get SS API Key" even runs when there are no users available, 'archivematica_src_configure_ss_api_key' will be empty/defined and prevents auto generation.
Eventually "Create SS superuser" will give an error because there is no 'API Key' defined.

This PR adds a 'when' status to "Get SS API Key" to check the results of "Check for SS user".