### PR TITLE
Pin pip version due to pip-tools error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This document describes important changes in this role.
 
 Most recent changes first:
 
+- 2021-10-26: variable `archivematica_src_pip_version` reinstated on
+  stable/1.13.x branch due to pip-tools issue with latest pip release
+
 - Variables `archivematica_src_pip_version`,
   `archivematica_src_setuptools_version` and `archivematica_src_wheel_version`
   are abandoned since we don't need them in the Python 3 environment.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -135,6 +135,7 @@ archivematica_src_ssl_include_acme_chlg_loc: "false"
 #
 
 # Pip version
+archivematica_src_pip_version: "21.2.4"
 archivematica_src_pip_tools_version: "5.5.0"
 
 # Sample data

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -41,7 +41,7 @@
       dest: "/root/get-pip.py"
 
   - name: "Install pip with get-pip.py"
-    command: "{{ archivematica_src_virtualenv_python }} get-pip.py"
+    command: "{{ archivematica_src_virtualenv_python }} get-pip.py pip=={{ archivematica_src_pip_version }}"
     args:
       chdir: "/root/"
 

--- a/tasks/pipeline-pip-deps.yml
+++ b/tasks/pipeline-pip-deps.yml
@@ -19,7 +19,9 @@
     virtualenv: "{{ archivematica_src_am_virtualenv }}"
     virtualenv_command: "{{ archivematica_src_virtualenv }}"
     virtualenv_python: "{{ archivematica_src_virtualenv_python }}"
-    name: "pip-tools=={{ archivematica_src_pip_tools_version }}"
+    name: 
+      - "pip=={{ archivematica_src_pip_version }}"
+      - "pip-tools=={{ archivematica_src_pip_tools_version }}"
 
 - name: "Synchronize requirements"
   command: "{{ archivematica_src_am_virtualenv }}/bin/pip-sync {{ 'requirements-dev-py3.txt' if is_dev else 'requirements-py3.txt' }}"

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -69,7 +69,9 @@
     virtualenv: "{{ archivematica_src_ss_virtualenv }}"
     virtualenv_command: "{{ archivematica_src_virtualenv }}"
     virtualenv_python: "{{ archivematica_src_virtualenv_python }}"
-    name: "pip-tools=={{ archivematica_src_pip_tools_version }}"
+    name: 
+      - "pip=={{ archivematica_src_pip_version }}"
+      - "pip-tools=={{ archivematica_src_pip_tools_version }}"
   tags: "amsrc-ss-pydep"
 
 - name: "Synchronize requirements"


### PR DESCRIPTION
Pin pip version to prevent pip-tools error.

Fixes https://github.com/archivematica/Issues/issues/1508