### PR TITLE
Change pip tool version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -135,7 +135,7 @@ archivematica_src_ssl_include_acme_chlg_loc: "false"
 #
 
 # Pip version
-archivematica_src_pip_tools_version: "5.5.0"
+archivematica_src_pip_tools_version: "6.4.0"
 
 # Sample data
 archivematica_src_install_sample_data_timeout: "3600"


### PR DESCRIPTION
This commit updates the pip version to 6.4.0 and thus fixes the issue 
regarding pip-sync from pip-tools as mentioned here https://github.com/jazzband/pip-tools/issues/1503.

Connects to https://github.com/archivematica/Issues/issues/1508.