### PR TITLE
Find SS 0.19 requirements file

### DIFF
--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -69,13 +69,32 @@
     virtualenv: "{{ archivematica_src_ss_virtualenv }}"
     virtualenv_command: "{{ archivematica_src_virtualenv }}"
     virtualenv_python: "{{ archivematica_src_virtualenv_python }}"
-    name: 
+    name:
       - "pip=={{ archivematica_src_pip_version }}"
       - "pip-tools=={{ archivematica_src_pip_tools_version }}"
   tags: "amsrc-ss-pydep"
 
+- name: "Stat requirements file"
+  stat:
+    path: "{{ archivematica_src_dir }}/archivematica-storage-service/requirements/production-py3.txt"
+    get_checksum: "no"
+  register: requirements_stat
+  tags: "amsrc-ss-pydep"
+
+- name: "Define requirements file"
+  set_fact:
+    requirements_file: "{{ 'local-py3.txt' if is_dev else 'production-py3.txt' }}"
+  when: "requirements_stat.stat.exists"
+  tags: "amsrc-ss-pydep"
+
+- name: "Define requirements file"
+  set_fact:
+    requirements_file: "{{ 'local.txt' if is_dev else 'production.txt' }}"
+  when: "not requirements_stat.stat.exists"
+  tags: "amsrc-ss-pydep"
+
 - name: "Synchronize requirements"
-  command: "{{ archivematica_src_ss_virtualenv }}/bin/pip-sync {{ 'local-py3.txt' if is_dev else 'production-py3.txt' }}"
+  command: "{{ archivematica_src_ss_virtualenv }}/bin/pip-sync {{ requirements_file }}"
   args:
     chdir: "{{ archivematica_src_dir }}/archivematica-storage-service/requirements"
   environment:


### PR DESCRIPTION
This commit ensures that Archivematica 1.13 can be installed using both SS 0.18 and 0.19. In the latter version, the path of the requirements file has changed again.

Only needed in `stable/1.13.x` because we don't expect `qa/1.x` to be used to deploy Archivematica installations with Storage Service 0.18.

Connects to https://github.com/archivematica/Issues/issues/1522.