### PR TITLE
get-pip: Update URL to use 3.6 script

### DIFF
--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -36,7 +36,7 @@
 
   - name: "Download get-pip.py"
     get_url:
-      url: "https://bootstrap.pypa.io/pip/get-pip.py"
+      url: "https://bootstrap.pypa.io/pip/3.6/get-pip.py"
       force: "yes"
       dest: "/root/get-pip.py"
 


### PR DESCRIPTION
Connects to:

 https://github.com/artefactual-labs/ansible-archivematica-src/issues/363