### PR TITLE
ss-migrate-sqlite3: fix django_manage loaddata task

### DIFF
--- a/tasks/ss-migrate-sqlite3.yml
+++ b/tasks/ss-migrate-sqlite3.yml
@@ -60,7 +60,7 @@
       --natural-foreign
       --natural-primary
       --indent 4
-      --output /tmp/datadump_{{ date_result.stdout }}.json
+      --output /tmp/datadump_{{ date_result.stdout }}.json
     app_path: "{{ archivematica_src_ss_app }}"
     virtualenv: "{{ archivematica_src_ss_virtualenv }}"
   environment: "{{ __archivematica_src_ss_environment_remove_SS_DB_URL }}"
@@ -88,8 +88,8 @@
   become: "yes"
   become_user: "archivematica"
   django_manage:
-    command: >
-      loaddata /tmp/datadump_{{ date_result.stdout }}.json
+    command: "loaddata"
+    fixtures: "/tmp/datadump_{{ date_result.stdout }}.json"
     app_path: "{{ archivematica_src_ss_app }}"
     virtualenv: "{{ archivematica_src_ss_virtualenv }}"
   environment: "{{ archivematica_src_ss_environment }}"


### PR DESCRIPTION
Use the fixtures param to pass the fixture file name (https://docs.ansible.com/ansible/latest/collections/community/general/django_manage_module.html)

Fixes #374