### PR TITLE
Add Ubuntu Focal support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,8 +12,19 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - bionic
+    - focal
 
 dependencies:
+
+# Use different node and geerlingguy.nodejs role versions on Ubuntu >=20.04
+- role: geerlingguy.nodejs
+  version: "{% if ansible_distribution_version is version('20.04', '>=') %}6.1.1{% else %}4.1.1{% endif %}"
+  nodejs_version: "{% if ansible_distribution_version is version('20.04', '>=') %}10.x{% else %}8.x{% endif %}"
+  when:
+    - ansible_distribution == "Ubuntu"
+
 - role: geerlingguy.nodejs
   version: 4.1.1
   nodejs_version: 8.x
+  when:
+    - ansible_os_family == "RedHat"

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -29,6 +29,13 @@
         - "python2-pip"
       state: "absent"
 
+  - name: "Add Deadsnakes APT repository (Ubuntu >=20.04)"
+    apt_repository:
+      repo: "ppa:deadsnakes"
+    when:
+      - ansible_os_family == "Debian"
+      - ansible_distribution_version is version_compare('20.04', '>=')
+
   - name: "Ensure Python 3 is installed"
     package:
       name: "{{ archivematica_src_python_packages }}"

--- a/tasks/pipeline-osdeps-MCPClient.yml
+++ b/tasks/pipeline-osdeps-MCPClient.yml
@@ -1,6 +1,18 @@
 ---
 # ubuntu block
 - block:
+    - name: "Install mediaarea.net repo (mediaconch, mediainfo) (Ubuntu >=20.04)"
+      apt:
+        deb: "https://mediaarea.net/repo/deb/repo-mediaarea_1.0-21_all.deb"
+      when:
+        - "ansible_distribution_version is version('20.04', '>=')"
+
+    - name: "Update apt cache (Ubuntu >=20.04)"
+      apt:
+        update_cache: yes
+      when:
+        - "ansible_distribution_version is version('20.04', '>=')"
+
     - name: "Install MCPClient ext. deps. repo keys"
       apt_key:
         id: "{{ item.id }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,12 +1,13 @@
 ---
 systemd_environment_path: "/etc/default"
+__python_packages_prefix: "{% if ansible_python.version.major >= 3 %}python3{% else %}python{% endif %}"
 ansible_deps:
-  - "python-pycurl"
-  - "python-setuptools"
+  - "{{ __python_packages_prefix }}-pycurl"
+  - "{{ __python_packages_prefix }}-setuptools"
   - "git"
-  - "python-mysqldb"  # Required for mysql_db module
-  - "sqlite3"         # Required for am-configure and fixity
-  - "ca-certificates" # Required for apt-get
+  - "{{ __python_packages_prefix }}-mysqldb"  # Required for mysql_db module
+  - "sqlite3"                                 # Required for am-configure and fixity
+  - "ca-certificates"                         # Required for apt-get
 ca_custom_bundle: "/etc/ssl/certs/ca-certificates.crt"
 archivematica_src_am_amauat_deps:
   - "tightvncserver"


### PR DESCRIPTION
- Use deadsnakes repo for Python on Ubuntu20
- Use mediaarea.net repo for mediaconch and mediainfo on Ubuntu20
- Use node 10.x and geerlingguy.nodejs 6.1.1 for Ubuntu20
- Update meta

Connects to https://github.com/archivematica/Issues/issues/1590