### PR TITLE
fixity: remove dupe emails

### DIFF
--- a/templates/bin/fixity-cron
+++ b/templates/bin/fixity-cron
@@ -12,7 +12,7 @@ function get_emails(){
                 cd /usr/lib/archivematica/storage-service
                 echo 'select email from auth_user;' | \
                         /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python \
-                        manage.py dbshell 2> /dev/null | tail -n+2 | grep -v "x@x"| grep -v ^$
+                        manage.py dbshell 2> /dev/null | tail -n+2 | grep -v 'x@x'| grep -v ^$ | sort -u
 ";
 }
 


### PR DESCRIPTION
Prevent `fixity-cron` to send duplicated emails to the same inbox.

Cosmetic change: use single quotes instead of double ones in the `fixity-cron` script, inside a piped command.