### PR TITLE
MCPClient: name service using decimal numbers

### DIFF
--- a/tasks/pipeline-environment.yml
+++ b/tasks/pipeline-environment.yml
@@ -55,7 +55,7 @@
     - src: "etc/systemd/system/archivematica-mcp-client.service.j2"
       dest: "/etc/systemd/system/archivematica-mcp-client.service"
   when: "archivematica_src_am_mcpclient_instances == 1"
-
+  tags: amsrc-mcp-client
 
 - name: "Configure mcp-clients (multiple)"
   block:
@@ -71,23 +71,24 @@
   - name: "Create extra systemd mcpclient services"
     template:
       src: "etc/systemd/system/archivematica-mcp-client.service.j2"
-      dest: "/etc/systemd/system/archivematica-mcp-client-{{ '%1x' | format(item) }}.service"
+      dest: "/etc/systemd/system/archivematica-mcp-client-{{ '%1d' | format(item) }}.service"
     loop: "{{ range(1, archivematica_src_am_mcpclient_instances|int  + 1, 1)|list }}"
 
   - name: "Configure extra mcp-clients"
     template:
       src: "etc/sysconfig/archivematica-mcp-client.j2"
-      dest: "{{ systemd_environment_path }}/{{ 'archivematica-mcp-client-%1x' | format(item) }}"
+      dest: "{{ systemd_environment_path }}/{{ 'archivematica-mcp-client-%1d' | format(item) }}"
     loop: "{{ range(1, archivematica_src_am_mcpclient_instances|int  + 1, 1)|list }}"
 
   - name: "Update prometheus port"
     lineinfile:
-      path: "{{ systemd_environment_path }}/{{ 'archivematica-mcp-client-%1x' | format(item) }}"
+      path: "{{ systemd_environment_path }}/{{ 'archivematica-mcp-client-%1d' | format(item) }}"
       regexp: "^ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_PROMETHEUS_BIND_PORT="
-      line: "ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_PROMETHEUS_BIND_PORT=911{{ '%1x' | format(item) }}"
+      line: "ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_PROMETHEUS_BIND_PORT=96{{ '%02d' | format(item|int) }}"
     loop: "{{ range(1, archivematica_src_am_mcpclient_instances|int  + 1, 1)|list }}"
 
   when: archivematica_src_am_mcpclient_instances > 1
+  tags: amsrc-mcp-client
 
 
 #
@@ -183,10 +184,11 @@
   when:
     - ansible_service_mgr == "systemd"
     - archivematica_src_am_mcpclient_instances ==  1
+  tags: amsrc-mcp-client
 
 - name: "Enable mcpclient service (multiple)"
   systemd:
-    name: "{{ 'archivematica-mcp-client-%1x' | format(item) }}"
+    name: "{{ 'archivematica-mcp-client-%1d' | format(item) }}"
     state: "restarted"
     enabled: "yes"
     daemon_reload: "yes"
@@ -194,5 +196,5 @@
   when:
     - ansible_service_mgr == "systemd"
     - archivematica_src_am_mcpclient_instances > 1
-
+  tags: amsrc-mcp-client
 

--- a/templates/etc/systemd/system/archivematica-mcp-client.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-client.service.j2
@@ -11,7 +11,7 @@ Group=archivematica
 {% if archivematica_src_am_mcpclient_instances == 1 %}
 EnvironmentFile=-{{ systemd_environment_path }}/archivematica-mcp-client
 {% else %}
-EnvironmentFile=-{{ systemd_environment_path }}/archivematica-mcp-client-{{ '%1x' | format(item) }}
+EnvironmentFile=-{{ systemd_environment_path }}/archivematica-mcp-client-{{ '%1d' | format(item) }}
 {% endif %}
 {% if archivematica_src_syslog_enabled|bool %}
 StandardOutput=syslog


### PR DESCRIPTION
 - Prometheus port set to 96XX , where XX is the number of the client
 - Added an "amsrc-mcp-client" tag to speed up deployment of different number of mcpclients

Fixes https://github.com/archivematica/Issues/issues/1540