### PR TITLE
Update mysql_db: Add collation and unix_socket

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,8 @@ archivematica_src_am_db_host: "localhost"        # Archivematica database host
 archivematica_src_am_db_name: "MCP"              # Archivematica database name
 archivematica_src_am_db_user: "archivematica"    # Archivematica database user
 archivematica_src_am_db_password: "demo"         # Archivematica database password
+archivematica_src_am_db_encoding: "utf8mb4"      # Archivematica database encoding
+archivematica_src_am_db_collation: "utf8mb4_0900_ai_ci" # Archivematica database collation
 
 archivematica_src_ss_db_mysql_enabled: "true"    # Use MySQL SS database. Set as false for sqlite3
 archivematica_src_ss_db_host: "localhost"        # Archivematica Storage Service database host
@@ -57,6 +59,8 @@ archivematica_src_ss_db_name: "SS"               # Archivematica Storage Service
 archivematica_src_ss_db_user: "archivematica"    # Archivematica Storage Service database user
 archivematica_src_ss_db_password: "demo"         # Archivematica Storage Service database password
 archivematica_src_ss_db_port: 3306               # Archivematica Storage Service database password
+archivematica_src_ss_db_encoding: "utf8mb4"      # Archivematica Storage Service database encoding
+archivematica_src_ss_db_collation: "utf8mb4_0900_ai_ci" # Archivematica Storage Service database collation
 
 
 # Reset data options

--- a/tasks/pipeline-dbconf.yml
+++ b/tasks/pipeline-dbconf.yml
@@ -12,14 +12,16 @@
   mysql_db:
     name: "{{ archivematica_src_am_db_name }}"
     state: "absent"
+    login_unix_socket: "{% if ansible_os_family == 'RedHat' %}/var/lib/mysql/mysql.sock{% else %}/var/run/mysqld/mysqld.sock{% endif %}"
   when: "archivematica_src_reset_mcpdb|bool or archivematica_src_reset_am_all|bool"
 
 - name: "Create MySQL database"
   mysql_db:
     name: "{{ archivematica_src_am_db_name }}"
     state: "present"
-    encoding: "utf8"
-    collation: "utf8_unicode_ci"
+    collation: "{{ archivematica_src_am_db_collation }}"
+    encoding: "{{ archivematica_src_am_db_encoding }}"
+    login_unix_socket: "{% if ansible_os_family == 'RedHat' %}/var/lib/mysql/mysql.sock{% else %}/var/run/mysqld/mysqld.sock{% endif %}"
   when: "archivematica_src_reset_mcpdb|bool or archivematica_src_reset_am_all|bool"
 
 

--- a/tasks/ss-db.yml
+++ b/tasks/ss-db.yml
@@ -15,6 +15,7 @@
   mysql_db:
     name: "{{ archivematica_src_ss_db_name }}"
     state: absent
+    login_unix_socket: "{% if ansible_os_family == 'RedHat' %}/var/lib/mysql/mysql.sock{% else %}/var/run/mysqld/mysqld.sock{% endif %}"
   when: 
     - "archivematica_src_reset_ss_db|bool"
     - "archivematica_src_ss_environment['SS_DB_URL'] is defined"
@@ -23,6 +24,9 @@
   mysql_db:
     name: "{{ archivematica_src_ss_db_name }}"
     state: present
+    collation: "{{ archivematica_src_ss_db_collation }}"
+    encoding: "{{ archivematica_src_ss_db_encoding }}"
+    login_unix_socket: "{% if ansible_os_family == 'RedHat' %}/var/lib/mysql/mysql.sock{% else %}/var/run/mysqld/mysqld.sock{% endif %}"
   when:
     - "archivematica_src_reset_ss_db|bool"
     - "archivematica_src_ss_environment['SS_DB_URL'] is defined"

--- a/tasks/ss-migrate-sqlite3.yml
+++ b/tasks/ss-migrate-sqlite3.yml
@@ -69,11 +69,15 @@
   mysql_db:
     name: "{{ archivematica_src_ss_db_name }}"
     state: absent
+    login_unix_socket: "{% if ansible_os_family == 'RedHat' %}/var/lib/mysql/mysql.sock{% else %}/var/run/mysqld/mysqld.sock{% endif %}"
 
 - name: "Create SS DB (mysql)"
   mysql_db:
     name: "{{ archivematica_src_ss_db_name }}"
     state: present
+    collation: "{{ archivematica_src_ss_db_collation }}"
+    encoding: "{{ archivematica_src_ss_db_encoding }}"
+    login_unix_socket: "{% if ansible_os_family == 'RedHat' %}/var/lib/mysql/mysql.sock{% else %}/var/run/mysqld/mysqld.sock{% endif %}"
 
 - name: "Run SS django database migrations (To syncdb database)"
   become: "yes"


### PR DESCRIPTION
The `login_unix_socket`  option was already added to percona role and all the tasks in playbooks that use the mysql ansible modules.

About the collation and encode new variables, it allows to define which encode/collation we want to use in MCP and SS databases.