### PR TITLE
Add AlmaLinux and OracleLinux support

### DIFF
--- a/tasks/automation-tools.yml
+++ b/tasks/automation-tools.yml
@@ -5,11 +5,11 @@
 - name: "Get git config global safe directories dir"
   shell: "git config --global --get-all safe.directory || echo ''"
   register: "__git_config_global_safe_dir"
-  become_flags: "-E"
+  become_flags: "-ES"
 
 - name: "Set Automation-Tools source directory as git safe dir"
   command: "git config --global --add safe.directory {{ archivematica_src_dir }}/automation-tools"
-  become_flags: "-E"
+  become_flags: "-ES"
   when:
     - archivematica_src_dir + '/automation-tools' not in __git_config_global_safe_dir.stdout_lines
 

--- a/tasks/common-RHEL.yml
+++ b/tasks/common-RHEL.yml
@@ -6,7 +6,7 @@
 
 - name: "Install EPEL repository on RHEL"
   yum:
-    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version|int }}.noarch.rpm"
     state: "present"
   when:
     - install_rpm_repositories|bool

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -42,7 +42,7 @@
   # Using the install-packages.yml task file prepared for osdeps
 
   # Ensure Python 3 is installed
-  - include: "install-packages.yml"
+  - include_tasks: "install-packages.yml"
     vars:
       packages: "{{ archivematica_src_python_packages }}"
       name: "Python 3"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   tags:
     - "always" # inocuous to use always here
 
-- include: "nodejs.yml"
+- include_tasks: "nodejs.yml"
   tags:
     - "amsrc-ss"
     - "amsrc-ss-websrv"
@@ -84,7 +84,7 @@
     - archivematica_src_ss_environment['SS_GUNICORN_WORKERS'] is not defined
   tags: "always"
 
-- include: "envs-patch-backward-compatibility.yml"
+- include_tasks: "envs-patch-backward-compatibility.yml"
   tags: "always"
 
 # Uncomment if you want to debug the environment strings.
@@ -111,7 +111,7 @@
   block:
 
   - name: "Include common-RHEL.yml for RHEL"
-    include: "common-RHEL.yml"
+    include_tasks: "common-RHEL.yml"
     when:
       - "ansible_distribution == 'RedHat'"
 
@@ -120,7 +120,7 @@
   # Using the install-packages.yml task file prepared for osdeps
 
   # Install necessary packages required by this ansible role
-  - include: "install-packages.yml"
+  - include_tasks: "install-packages.yml"
     vars:
       packages: "{{ ansible_deps }}"
       name: "Ansible dependencies"
@@ -128,7 +128,7 @@
       - ansible_deps|length>0
 
   - name: "Include common.yml common tasks for all components"
-    include: "common.yml"
+    include_tasks: "common.yml"
     tags: # do not use "always" tag in role, to avoid issues when including other roles in a playbook
       - "amsrc-common"
       - "amsrc-ss"
@@ -164,7 +164,7 @@
 # archivematica-storage-service
 #
 
-- include: "ss-main.yml"
+- include_tasks: "ss-main.yml"
   tags:
     - "amsrc-ss"
   when:
@@ -179,15 +179,15 @@
 
 - name: "Complete storage service deployment"
   block:
-  - include: "ss-db.yml"
+  - include_tasks: "ss-db.yml"
     tags:
       - "amsrc-ss"
       - "amsrc-ss-db"
-  - include: "ss-osconf.yml"
+  - include_tasks: "ss-osconf.yml"
     tags:
       - "amsrc-ss"
       - "amsrc-ss-osconf"
-  - include: "ss-websrv-gunicorn.yml"
+  - include_tasks: "ss-websrv-gunicorn.yml"
     tags:
       - "amsrc-ss"
       - "amsrc-ss-websrv"
@@ -195,7 +195,7 @@
     - "archivematica_src_install_ss|bool or
        archivematica_src_install_ss == 'rpm'"
 
-- include: "ss-migrate-sqlite3.yml"
+- include_tasks: "ss-migrate-sqlite3.yml"
   tags:
     - "amsrc-ss-migrate-sqlite3"
   when:
@@ -219,26 +219,26 @@
 #   6- web server config
 - name: "Install from source"
   block:
-  - include: "pipeline-clonecode.yml"
+  - include_tasks: "pipeline-clonecode.yml"
     tags:
       - "amsrc-pipeline"
       - "amsrc-pipeline-clonecode"
 
-  - include: "pipeline-osdeps.yml"
+  - include_tasks: "pipeline-osdeps.yml"
     tags:
       - "amsrc-pipeline"
       - "amsrc-pipeline-osdeps"
 
-  - include: "pipeline-pip-deps.yml"
+  - include_tasks: "pipeline-pip-deps.yml"
     tags:
       - "amsrc-pipeline"
       - "amsrc-pipeline-pipdeps"
-  - include: "pipeline-osconf.yml"
+  - include_tasks: "pipeline-osconf.yml"
     tags:
       - "amsrc-pipeline"
       - "amsrc-pipeline-osconf"
 
-  - include: "pipeline-instcode.yml"
+  - include_tasks: "pipeline-instcode.yml"
     tags:
       - "amsrc-pipeline"
       - "amsrc-pipeline-instcode"
@@ -254,22 +254,22 @@
 
 - name: "Complete AM deployment"
   block:
-  - include: "pipeline-dbconf.yml"
+  - include_tasks: "pipeline-dbconf.yml"
     tags:
       - "amsrc-pipeline"
       - "amsrc-pipeline-dbconf"
 
-  - include: "pipeline-es.yml"
+  - include_tasks: "pipeline-es.yml"
     tags:
       - "amsrc-pipeline"
       - "amsrc-pipeline-es"
 
-  - include: "pipeline-environment.yml"
+  - include_tasks: "pipeline-environment.yml"
     tags:
       - "amsrc-pipeline"
       - "amsrc-pipeline-environment"
 
-  - include: "pipeline-websrv-gunicorn.yml"
+  - include_tasks: "pipeline-websrv-gunicorn.yml"
     tags:
       - "amsrc-pipeline"
       - "amsrc-pipeline-websrv"
@@ -311,7 +311,7 @@
 # automation-tools
 #
 
-- include: "automation-tools.yml"
+- include_tasks: "automation-tools.yml"
   tags:
     - "amsrc-automationtools"
   when: "archivematica_src_install_automationtools|bool"
@@ -321,7 +321,7 @@
 # acceptance-tests
 #
 
-- include: "acceptance-tests.yml"
+- include_tasks: "acceptance-tests.yml"
   tags:
     - "amsrc-acceptancetests"
   when: "archivematica_src_install_acceptance_tests|bool"
@@ -331,7 +331,7 @@
 # fixity
 #
 
-- include: "fixity.yml"
+- include_tasks: "fixity.yml"
   tags:
     - "amsrc-fixity"
   when: "archivematica_src_install_fixity|bool"
@@ -340,7 +340,7 @@
 # Configure pipeline and SS
 #
 
-- include: "configure.yml"
+- include_tasks: "configure.yml"
   tags:
     - "amsrc-configure"
   when: "archivematica_src_configure_ss|bool or archivematica_src_configure_dashboard|bool"
@@ -349,7 +349,7 @@
 # Configure GPG locations
 #
 
-- include: "configure-gpg.yml"
+- include_tasks: "configure-gpg.yml"
   tags:
     - "amsrc-configure"
   when:

--- a/tasks/pipeline-clonecode.yml
+++ b/tasks/pipeline-clonecode.yml
@@ -15,11 +15,11 @@
 - name: "Get git config global safe directories dir"
   shell: "git config --global --get-all safe.directory || echo ''"
   register: "__git_config_global_safe_dir"
-  become_flags: "-E"
+  become_flags: "-ES"
 
 - name: "Set AM source directory as git safe dir"
   command: "git config --global --add safe.directory {{ archivematica_src_dir }}/archivematica"
-  become_flags: "-E"
+  become_flags: "-ES"
   when:
     - archivematica_src_dir + '/archivematica' not in __git_config_global_safe_dir.stdout_lines
 
@@ -31,4 +31,4 @@
     force: "yes"
     accept_hostkey: "yes"
     recursive: "no"
-  become_flags: "-E"    
+  become_flags: "-ES"

--- a/tasks/pipeline-osdeps.yml
+++ b/tasks/pipeline-osdeps.yml
@@ -51,7 +51,8 @@
       # Needed by fits, ffmpeg, mediainfo and mediaconch
       command: "dnf config-manager --set-enabled powertools"
       when:
-        - ansible_distribution in ['CentOS','Rocky']
+        - ansible_distribution not in ['Redhat']
+        - ansible_os_family == 'RedHat'
         - ansible_distribution_major_version|int == 8
 
     - name: "Enable CodeReady Linux Builder Repository on RHEL 8"
@@ -86,7 +87,7 @@
         - dashboard_osdeps.repos + MCPServer_osdeps.repos + MCPClient_osdeps.repos
 
   when:
-    - ansible_distribution in ['RedHat','CentOS','Rocky']
+    - ansible_os_family in [ 'RedHat', 'Rocky' ]
     - install_rpm_repositories|bool
 # End RH/CentOS/Rocky block
 
@@ -95,7 +96,7 @@
 # But yum or apt modules doesn't allow loops (deprecated) so the trick is using the
 # install-packages.yml task file
 
-- include: "install-packages.yml"
+- include_tasks: "install-packages.yml"
   vars:
     packages: "{{ item.packages }}"
     name: "{{ item.name }}"

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -16,12 +16,12 @@
 - name: "Get git config global safe directories dir"
   shell: "git config --global --get-all safe.directory || echo ''"
   register: "__git_config_global_safe_dir"
-  become_flags: "-E"
+  become_flags: "-ES"
   tags: "amsrc-ss-clone"
 
 - name: "Set AM source directory as git safe dir"
   command: "git config --global --add safe.directory {{ archivematica_src_dir }}/archivematica-storage-service"
-  become_flags: "-E"
+  become_flags: "-ES"
   when:
     - archivematica_src_dir + '/archivematica-storage-service' not in __git_config_global_safe_dir.stdout_lines
   tags: "amsrc-ss-clone"
@@ -33,7 +33,7 @@
     version: "{{ archivematica_src_ss_version }}"
     force: "yes"
     accept_hostkey: "yes"
-  become_flags: "-E"
+  become_flags: "-ES"
   tags: "amsrc-ss-clone"
 
 # For some reason, some dirs in the cloned source code

--- a/tasks/ss-osdeps.yml
+++ b/tasks/ss-osdeps.yml
@@ -54,7 +54,7 @@
         - storage_service_osdeps.repos
 
   when:
-    - ansible_distribution in ['RedHat','CentOS','Rocky']
+    - ansible_os_family in ['RedHat','Rocky']
     - install_rpm_repositories|bool
 # End RH/CentOS/Rocky block
 
@@ -63,7 +63,7 @@
 # But yum or apt modules doesn't allow loops (deprecated) so the trick is using the
 # install-packages.yml task file
 
-- include: "install-packages.yml"
+- include_tasks: "install-packages.yml"
   vars:
     packages: "{{ item.packages }}"
     name: "{{ item.name }}"

--- a/vars/AlmaLinux-9.yml
+++ b/vars/AlmaLinux-9.yml
@@ -1,0 +1,116 @@
+---
+systemd_environment_path: "/etc/sysconfig"
+ansible_deps:
+#  - "epel-release"
+  - "acl"                     # Required to avoid using allow_world_readable_tmpfiles=True
+  - "python3-setuptools"
+  - "git"
+  - "python3-PyMySQL"         # Required for mysql_db module
+  - "sqlite"                  # Required for am-configure and fixity
+  - "p7zip-plugins"
+  - "python3-policycoreutils" # Required by SELinux management
+  - "python3-libsemanage"     # Required by SELinux management
+  - "ca-certificates"         # Required for yum
+ca_custom_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
+archivematica_src_am_amauat_deps: []
+archivematica_src_am_fixity_deps:
+  - "sqlite"
+  - "moreutils"
+  - "s-nail"                  # Replaces mailx
+archivematica_src_python_packages:
+  - "python3-devel"
+  - "python3-distutils-extra"
+  - "python3-setuptools"
+  - "pkgconfig"
+
+dashboard_osdeps:
+  repokeys: []
+  repos: []
+  packages:
+    - gcc
+    - gcc-c++
+    - gettext    # only required in development environments (used to make string translateable)
+    - nginx
+    - python3-policycoreutils
+    - libffi-devel
+    - libxml2-devel
+    - libxslt-devel
+    - openssl-devel
+    - python3-devel
+    - openldap-devel
+    - unar
+    - coreutils
+
+MCPClient_osdeps:
+  repokeys:
+    - "https://packages.archivematica.org/GPG-KEY-archivematica-sha512" 
+  repos:
+    - baseurl: "https://packages.archivematica.org/1.15.x/rocky9-extras"
+      description: "archivematica extras"
+      enabled: "yes"
+      gpgcheck: "no"
+      name: "archivematica-extras"
+  packages:
+    - atool
+    - bulk_extractor
+    - ffmpeg
+    - fits
+    - gearmand
+    - ghostscript
+    - ImageMagick
+    - inkscape
+    - jhove
+    - libewf
+    - libxml2
+    - libpst
+    - libraw1394
+    - libvpx
+    - md5deep
+    - mediainfo
+    - mediaconch
+    - nfs-utils
+    - java-1.8.0-openjdk-headless
+    - openjpeg2
+    - p7zip
+    - p7zip-plugins
+    - pbzip2
+    - perl-Image-ExifTool
+    - postfix
+    - rsync
+    - siegfried
+    - sleuthkit
+    - tesseract
+    - tree
+    - uuid 
+
+MCPServer_osdeps:
+  repokeys: []
+  repos: []
+  packages: []
+
+storage_service_osdeps:
+  repokeys: []
+  repos: []
+  packages:
+    - epel-release  # required by unar and nginx
+  packages_2:
+    - nginx
+    - unar
+    - rsync
+    - python3-devel
+    - libxml2-devel
+    - libxslt-devel
+    - zlib-devel
+    - libffi-devel
+    - openssl-devel
+    - gcc           # required to build some pip dependencies
+    - gcc-c++
+    - gettext
+    - p7zip
+    - p7zip-plugins
+    - gnupg1
+    - rng-tools
+    - openldap-devel
+    - rclone
+
+nodejs_version: "14.x"

--- a/vars/OracleLinux-9.yml
+++ b/vars/OracleLinux-9.yml
@@ -1,0 +1,116 @@
+---
+systemd_environment_path: "/etc/sysconfig"
+ansible_deps:
+#  - "epel-release"
+  - "acl"                     # Required to avoid using allow_world_readable_tmpfiles=True
+  - "python3-setuptools"
+  - "git"
+  - "python3-PyMySQL"         # Required for mysql_db module
+  - "sqlite"                  # Required for am-configure and fixity
+  - "p7zip-plugins"
+  - "python3-policycoreutils" # Required by SELinux management
+  - "python3-libsemanage"     # Required by SELinux management
+  - "ca-certificates"         # Required for yum
+ca_custom_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
+archivematica_src_am_amauat_deps: []
+archivematica_src_am_fixity_deps:
+  - "sqlite"
+  - "moreutils"
+  - "s-nail"                  # Replaces mailx
+archivematica_src_python_packages:
+  - "python3-devel"
+  - "python3-distutils-extra"
+  - "python3-setuptools"
+  - "pkgconfig"
+
+dashboard_osdeps:
+  repokeys: []
+  repos: []
+  packages:
+    - gcc
+    - gcc-c++
+    - gettext    # only required in development environments (used to make string translateable)
+    - nginx
+    - python3-policycoreutils
+    - libffi-devel
+    - libxml2-devel
+    - libxslt-devel
+    - openssl-devel
+    - python3-devel
+    - openldap-devel
+    - unar
+    - coreutils
+
+MCPClient_osdeps:
+  repokeys:
+    - "https://packages.archivematica.org/GPG-KEY-archivematica-sha512" 
+  repos:
+    - baseurl: "https://packages.archivematica.org/1.15.x/rocky9-extras"
+      description: "archivematica extras"
+      enabled: "yes"
+      gpgcheck: "no"
+      name: "archivematica-extras"
+  packages:
+    - atool
+    - bulk_extractor
+    - ffmpeg
+    - fits
+    - gearmand
+    - ghostscript
+    - ImageMagick
+    - inkscape
+    - jhove
+    - libewf
+    - libxml2
+    - libpst
+    - libraw1394
+    - libvpx
+    - md5deep
+    - mediainfo
+    - mediaconch
+    - nfs-utils
+    - java-1.8.0-openjdk-headless
+    - openjpeg2
+    - p7zip
+    - p7zip-plugins
+    - pbzip2
+    - perl-Image-ExifTool
+    - postfix
+    - rsync
+    - siegfried
+    - sleuthkit
+    - tesseract
+    - tree
+    - uuid 
+
+MCPServer_osdeps:
+  repokeys: []
+  repos: []
+  packages: []
+
+storage_service_osdeps:
+  repokeys: []
+  repos: []
+  packages:
+    - epel-release  # required by unar and nginx
+  packages_2:
+    - nginx
+    - unar
+    - rsync
+    - python3-devel
+    - libxml2-devel
+    - libxslt-devel
+    - zlib-devel
+    - libffi-devel
+    - openssl-devel
+    - gcc           # required to build some pip dependencies
+    - gcc-c++
+    - gettext
+    - p7zip
+    - p7zip-plugins
+    - gnupg1
+    - rng-tools
+    - openldap-devel
+    - rclone
+
+nodejs_version: "14.x"


### PR DESCRIPTION
* Add almalinux and oraclelinux support
* Use include_tasks instead of include (not supported ansible 2.16)
* Fix install EPEL repo in RHEL (it was installing always EL7 version)
* Use become_flags=-ES (add S option) because it was failing in Almalinux and OracleLinux (and probably all RH related distros) when using become_pass. Error:

    "module_stderr": "sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper\nsudo: a password is required\n",

Connects to https://github.com/archivematica/Issues/issues/1634