### PR TITLE
Upgrade Node JS version

### DIFF
--- a/vars/AlmaLinux-9.yml
+++ b/vars/AlmaLinux-9.yml
@@ -113,4 +113,4 @@ storage_service_osdeps:
     - openldap-devel
     - rclone
 
-nodejs_version: "14.x"
+nodejs_version: "20.x"

--- a/vars/OracleLinux-9.yml
+++ b/vars/OracleLinux-9.yml
@@ -113,4 +113,4 @@ storage_service_osdeps:
     - openldap-devel
     - rclone
 
-nodejs_version: "14.x"
+nodejs_version: "20.x"

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -113,4 +113,4 @@ storage_service_osdeps:
     - openldap-devel
     - rclone
 
-nodejs_version: "14.x"
+nodejs_version: "20.x"

--- a/vars/Rocky-9.yml
+++ b/vars/Rocky-9.yml
@@ -113,4 +113,4 @@ storage_service_osdeps:
     - openldap-devel
     - rclone
 
-nodejs_version: "14.x"
+nodejs_version: "20.x"

--- a/vars/Ubuntu-22.yml
+++ b/vars/Ubuntu-22.yml
@@ -112,4 +112,4 @@ storage_service_osdeps:
     - libldap2-dev
     - rclone
 
-nodejs_version: "14.x"
+nodejs_version: "20.x"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -36,7 +36,7 @@ archivematica_src_python_packages: []  # Distro specific (see Debian.yml and Red
 # Set the version of Node.js to install ("12.x", "13.x", "14.x", "15.x", etc.).
 # Version numbers from Nodesource: https://github.com/nodesource/distributions
 # Thios variable can be override in var/$DISTRO-$MAJOR_VERSION
-nodejs_version: "10.x"
+nodejs_version: "20.x"
 
 # The user for whom the npm packages will be installed.
 # nodejs_install_npm_user: username


### PR DESCRIPTION
This upgrades Node JS to match https://github.com/artefactual/archivematica/pull/1875 where the frontend apps rely on `npm` > 9.