### PR TITLE
pipeline-osdeps: Update mediaarea repo version

### DIFF
--- a/tasks/pipeline-osdeps-MCPClient.yml
+++ b/tasks/pipeline-osdeps-MCPClient.yml
@@ -3,7 +3,7 @@
 - block:
     - name: "Install mediaarea.net repo (mediaconch, mediainfo) (Ubuntu >=20.04)"
       apt:
-        deb: "https://mediaarea.net/repo/deb/repo-mediaarea_1.0-21_all.deb"
+        deb: "https://mediaarea.net/repo/deb/repo-mediaarea_1.0-24_all.deb"
       when:
         - "ansible_distribution_version is version('20.04', '>=')"
 


### PR DESCRIPTION
Update mediaarea repo version.

If the server packages are updated you got the error:

```
TASK [roles/artefactual.archivematica-src : Install mediaarea.net repo (mediaconch, mediainfo) (Ubuntu >=20.04)] *********************************************************
Thursday 23 November 2023  11:48:35 +0100 (0:00:00.320)       0:04:11.013 *****
fatal: [XXXXXXXXX]: FAILED! => {"changed": false, "msg": "A later version is already installed"}
```