### PR TITLE
atom-user: Use ed25519 ssh key

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -156,7 +156,8 @@
   user:
     name: "archivematica"
     generate_ssh_key: "yes"
-    ssh_key_file: ".ssh/id_rsa"
+    ssh_key_type: "ed25519"
+    ssh_key_file: ".ssh/id_ed25519"
   when:
     - archivematica_src_configure_dashboard|bool
     - archivematica_src_configure_dashboardsettings is defined
@@ -174,7 +175,7 @@
     - archivematica_src_configure_dashboardsettings is defined
 
 - name: "Register ssh key"
-  command: cat /var/lib/archivematica/.ssh/id_rsa.pub
+  command: cat /var/lib/archivematica/.ssh/id_ed25519.pub
   register: ssh_key
   when:
     - archivematica_src_configure_dashboard|bool


### PR DESCRIPTION
Use ed25519 ssh key instead of obsolete rsa key.