### PR TITLE
Make Ubuntu mediainfo repo package URL configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -149,6 +149,17 @@ archivematica_src_ssl_include_acme_chlg_loc: "false"
 archivematica_src_pip_version: "21.3.1"
 archivematica_src_pip_tools_version: "6.4.0"
 
+#
+# Ubuntu mediainfo package
+#
+
+# Set archivematica_src_mediainfo_repo_package_latest=False if you want to use directly archivematica_src_mediainfo_repo_package_url URL.
+# When archivematica_src_mediainfo_repo_package_latest=True the latest mediainfo version is retrieved from github repo. Then that
+# repo package url is checked, when the package doesn't exist: archivematica_src_mediainfo_repo_package_url is used
+
+archivematica_src_mediainfo_repo_package_latest: True
+archivematica_src_mediainfo_repo_package_url: "https://mediaarea.net/repo/deb/repo-mediaarea_1.0-24_all.deb"
+
 # Sample data
 archivematica_src_install_sample_data_timeout: "3600"
 archivematica_src_sample_data_version: "master"

--- a/tasks/pipeline-osdeps-get-latest-mediainfo-url.yml
+++ b/tasks/pipeline-osdeps-get-latest-mediainfo-url.yml
@@ -1,0 +1,28 @@
+- name: "Get the latest release of MediaInfo from GitHub"
+  uri:
+    url: https://api.github.com/repos/MediaArea/MediaInfo/releases/latest
+    method: GET
+    headers:
+      Accept: application/vnd.github.v3+json
+  register: __mediainfo_result
+
+
+- name: "Extract MediaInfo major version number"
+  set_fact:
+    __mediainfo_major_version: "{{ (__mediainfo_result.json.tag_name | regex_search('^[vV]?(\\d+)', '\\1') | first) | string }}"
+
+- name: "Check if the repo package URL is valid"
+  uri:
+    url: "https://mediaarea.net/repo/deb/repo-mediaarea_1.0-{{ __mediainfo_major_version }}_all.deb"
+    method: HEAD
+  register: __mediainfo_url_response
+
+- name: "Set variable if URL when package exists"
+  set_fact:
+    archivematica_src_mediainfo_repo_package_url_latest: "https://mediaarea.net/repo/deb/repo-mediaarea_1.0-{{ __mediainfo_major_version }}_all.deb"   
+  when: __mediainfo_url_response.status == 200
+
+- name: "Set variable if URL is not valid"
+  set_fact:
+    archivematica_src_mediainfo_repo_package_url_latest: "{{ archivematica_src_mediainfo_repo_package_url }}"
+  when: __mediainfo_url_response.status != 200

--- a/tasks/pipeline-osdeps.yml
+++ b/tasks/pipeline-osdeps.yml
@@ -9,11 +9,25 @@
 
 # ubuntu block
 - block:
-    - name: "Install mediaarea.net repo (mediaconch, mediainfo) (Ubuntu >=20.04)"
+    - name: "Install mediaarea.net repo (mediaconch, mediainfo) (Ubuntu >=20.04) (Fixed URL)"
       apt:
-        deb: "https://mediaarea.net/repo/deb/repo-mediaarea_1.0-21_all.deb"
+        deb: "{{ archivematica_src_mediainfo_repo_package_url }}"
       when:
         - "ansible_distribution_version is version('20.04', '>=')"
+        - not archivematica_src_mediainfo_repo_package_latest|bool
+
+    - name: "Get latest mediainfo repo package URL"
+      include_tasks: "pipeline-osdeps-get-latest-mediainfo-url.yml"
+      when:
+        - "ansible_distribution_version is version('20.04', '>=')"
+        - archivematica_src_mediainfo_repo_package_latest|bool
+
+    - name: "Install mediaarea.net repo (mediaconch, mediainfo) (Ubuntu >=20.04) (Latest)"
+      apt:
+        deb: "{{ archivematica_src_mediainfo_repo_package_url_latest | default(archivematica_src_mediainfo_repo_package_url) }}"
+      when:
+        - "ansible_distribution_version is version('20.04', '>=')"
+        - archivematica_src_mediainfo_repo_package_latest|bool
 
     - name: "Update apt cache (Ubuntu >=20.04)"
       apt:


### PR DESCRIPTION
The mediainfo repo package URL was hardcoded and mediaarea doesn't have a latest metapackage or symlink. So this commit:

* Allows to retrieve latest package URL
* Allows to set in default/main.yml a variable with a fixed package URL
* When the deduced latest package doesn't exist: the fixed package URL is used