### PR TITLE
Update Node.js tasks for Debian

### DIFF
--- a/tasks/nodejs.yml
+++ b/tasks/nodejs.yml
@@ -19,8 +19,8 @@
 
   - name: "Nodejs: Add Nodesource apt key"
     apt_key:
-      url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
-      id: "68576280"
+      url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x6F71F525282841EEDAF851B42F59B5F99B1BE0B4
+      id: "2F59B5F99B1BE0B4"
       state: present
 
   - name: "Nodejs: Add NodeSource repositories for Node.js"
@@ -28,8 +28,8 @@
       repo: "{{ item }}"
       state: present
     with_items:
-      - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
-      - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
+      - "deb https://deb.nodesource.com/node_{{ nodejs_version }} nodistro main"
+      - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} nodistro main"
     register: node_repo
 
   - name: "Nodejs: Update apt cache if repo was added"

--- a/vars/AlmaLinux-9.yml
+++ b/vars/AlmaLinux-9.yml
@@ -112,5 +112,3 @@ storage_service_osdeps:
     - rng-tools
     - openldap-devel
     - rclone
-
-nodejs_version: "20.x"

--- a/vars/OracleLinux-9.yml
+++ b/vars/OracleLinux-9.yml
@@ -112,5 +112,3 @@ storage_service_osdeps:
     - rng-tools
     - openldap-devel
     - rclone
-
-nodejs_version: "20.x"

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -112,5 +112,3 @@ storage_service_osdeps:
     - rng-tools
     - openldap-devel
     - rclone
-
-nodejs_version: "20.x"

--- a/vars/Rocky-9.yml
+++ b/vars/Rocky-9.yml
@@ -112,5 +112,3 @@ storage_service_osdeps:
     - rng-tools
     - openldap-devel
     - rclone
-
-nodejs_version: "20.x"

--- a/vars/Ubuntu-22.yml
+++ b/vars/Ubuntu-22.yml
@@ -111,5 +111,3 @@ storage_service_osdeps:
     - libsasl2-dev
     - libldap2-dev
     - rclone
-
-nodejs_version: "20.x"


### PR DESCRIPTION
This updates the repository used for installing Node.js in Debian distributions and removes the `nodejs_version` variable from the `vars` directory so it can be overridden from playbooks.

Connected to https://github.com/artefactual-labs/ansible-archivematica-src/issues/400
Connected to https://github.com/artefactual-labs/ansible-archivematica-src/issues/401