### PR TITLE
systemd: Add 5 retries to system mcpclient

### DIFF
--- a/templates/etc/systemd/system/archivematica-mcp-client.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-client.service.j2
@@ -3,6 +3,8 @@
 [Unit]
 Description=Archivematica MCP Client Service
 After=syslog.target network.target
+StartLimitInterval=200
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -20,6 +22,8 @@ SyslogIdentifier=MCPClientStdout
 SyslogFacility={{ archivematica_src_syslog_mcpclient_facility }}
 {% endif %}
 ExecStart={{ archivematica_src_am_mcpclient_virtualenv }}/bin/python {{ archivematica_src_am_mcpclient_app }}/archivematicaClient.py
+Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The mysql service can take several seconds to be up or start after mcpclient. Adding the retries to the mcpclient systemd file will fix the issue.

The same fix was done to dashboard a few years ago:

https://github.com/artefactual-labs/ansible-archivematica-src/commit/fae797cdf567974ef0b148317901c6c24f671e5e

Connects to https://github.com/archivematica/Issues/issues/1521