### PR TITLE
Add configuration for pipeline localfs spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ Archivematica installation from its source code repositories.
 
 - [Role Variables](#role-variables)
 - [Environment variables](#environment-variables)
+- [Database requirements](#database-requirements)
 - [Backward-compatible logging](#backward-compatible-logging)
+- [Configure ClamAV](#configure-clamav)
+- [Disable Elasticsearch use](#disable-elasticsearch-use)
+- [Deploy separate SS and pipeline](#deploy-separate-ss-and-pipeline)
 - [Tags](#tags)
 - [Dependencies](#dependencies)
 - [Example Playbooks](#example-playbooks)
@@ -26,10 +30,10 @@ Environment variables
 
 The following are role variables that can be used to pass dictionaries containing environment variables that will be passed to the different Archivematica components:
 
-- [Dashboard](https://github.com/artefactual/archivematica/tree/stable/1.7.x/src/dashboard/install/README.md): `archivematica_src_am_dashboard_environment`
-- [MCPServer](https://github.com/artefactual/archivematica/tree/stable/1.7.x/src/MCPServer/install/README.md): `archivematica_src_am_mcpserver_environment`
-- [MCPClient](https://github.com/artefactual/archivematica/tree/stable/1.7.x/src/MCPClient/install/README.md): `archivematica_src_am_mcpclient_environment`
-- [Storage Service](https://github.com/artefactual/archivematica-storage-service/tree/stable/0.11.x/install/README.md): `archivematica_src_ss_environment`
+- [Dashboard](https://github.com/artefactual/archivematica/tree/stable/1.16.x/src/dashboard/install/README.md): `archivematica_src_am_dashboard_environment`
+- [MCPServer](https://github.com/artefactual/archivematica/tree/stable/1.16.x/src/MCPServer/install/README.md): `archivematica_src_am_mcpserver_environment`
+- [MCPClient](https://github.com/artefactual/archivematica/tree/stable/1.16.x/src/MCPClient/install/README.md): `archivematica_src_am_mcpclient_environment`
+- [Storage Service](https://github.com/artefactual/archivematica-storage-service/tree/stable/0.22.x/install/README.md): `archivematica_src_ss_environment`
 
 The default values for these dictionaries can be found in [`vars/envs.yml`](vars/envs.yml). The user-provided dictionaries are combined with the defaults.
 
@@ -145,6 +149,42 @@ Disable Elasticsearch use
 
 The default Archivematica install relies on Elasticsearch for different features (Archival storage, Backlog and Appraisal tabs). If you need to disable them, the role variable `archivematica_src_search_enabled` has to be set to `False`
 
+Deploy separate SS and pipeline
+-------------------------------
+
+To deploy a separate Storage Service and pipeline, configure the following variable and dictionary (see examples in `defaults/main.yml`):
+
+* `archivematica_src_remote_pipeline`: The FQDN or IP address of the pipeline.
+* `archivematica_src_remote_locations`: A dictionary containing the locations to be enabled within the pipeline local filesystem space.
+
+This is the procedure for deploying separate SS and pipeline VMs:
+
+1. **Deploy the Storage Service (SS) VM**: Run the playbook, disabling the `amsrc-remote-pipeline` tag. For example:
+
+    ```bash
+    ansible-playbook am-ss.yml -t archivematica-src --skip-tags=amsrc-remote-pipeline -l my_SS_in_inventory
+    ```
+
+2. **Deploy the Pipeline VM**: Register the pipeline in the SS. No additional steps are required if using the `amsrc-configure` variables to create users and register the pipeline.
+
+3. **Finalize Configuration on the SS VM**: After both the SS and pipeline are deployed and the pipeline is registered, rerun the role on the SS VM with the `amsrc-remote-pipeline` tag enabled. For example:
+
+    ```bash
+    ansible-playbook am-ss.yml -t amsrc-remote-pipeline -l my_SS_in_inventory
+    ```
+
+**NOTE**: It is possible to deploy and configure more than one pipeline. For instance, if the `archivematica_src_remote_locations` configuration is identical across VMs, you can set `archivematica_src_remote_pipeline` for a second pipeline as an extra variable:
+
+```bash
+ansible-playbook am-ss.yml -t amsrc-remote-pipeline -l my_SS_in_inventory -e archivematica_src_remote_pipeline=MY_SECOND_PIPELINE_FQDN
+```
+
+Alternatively, use separate configuration files for each pipeline, defining `archivematica_src_remote_pipeline` and `archivematica_src_remote_locations` as needed, and load them with:
+
+```bash
+ansible-playbook am-ss.yml -e @file/pipeline2.yml -t amsrc-remote-pipeline MORE_OPTIONS_HERE
+```
+
 Tags
 ----
 
@@ -170,6 +210,7 @@ Note that if something is disabled with the [role variables](#role-variables), i
     - `amsrc-pipeline-websrv`: Configure webserver
 - `amsrc-automationtools`: Automation tools install
 - `amsrc-configure`: Create SS superuser & create dashboard admin & register pipeline on SS
+- `amsrc-remote-pipeline`: Create pipeline localfilesystem space and configure remote locations in SS (separate SS and pipeline)
 
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -210,6 +210,8 @@ archivematica_src_configure_am_org_name: "test org"          # Dashboard admin O
 archivematica_src_configure_am_org_id: "test id"             # Dashboard admin Org id
 archivematica_src_configure_am_whitelist: '""'               # Dashboard API whitelist, IP address or hostnames separated by blank spaces and inside quotes
 
+
+
 # Configure GPG
 # Uncomment this to add GPG AIPs Store and Backlog locations.
 #archivematica_src_configure_gpg:
@@ -276,4 +278,14 @@ archivematica_src_syslog_mcpserver_level: "DEBUG"
 #  - { location_purpose: "RP", location_path: "/replicator", location_description: "Replicator location", location_default: "false" }
 #  - { location_purpose: "AS", location_path: "/aipstore", location_description: "AipStore", location_default: "true" }
 #  - { location_purpose: "TS", location_path: "/transfer-source/", location_description: "Transfer Source", location_default: "false" }
+
+
+# Configure Remote pipeline
+#
+# The pipeline must be already registered in the SS!
+#archivematica_src_remote_pipeline: "archivematica.example.com"
+archivematica_src_remote_locations:
+  - { location_purpose: "CP", location_path: "/var/archivematica/sharedDirectory", location_description: "Remote processing", location_default: "true" }
+  - { location_purpose: "BL", location_path: "/var/archivematica/sharedDirectory/www/AIPsStore/transferBacklog", location_description: "Remote transfer backlog", location_default: "true" }
+#  - { location_purpose: "TS", location_path: "/home", location_description: "Remote transfer source", location_default: "true" }
 

--- a/tasks/configure-remote-pipeline.yml
+++ b/tasks/configure-remote-pipeline.yml
@@ -1,0 +1,145 @@
+---
+## Configure remote pipeline
+
+# Create key
+
+- name: "Configure SS: Create ssh key"
+  user:
+    name: "archivematica"
+    generate_ssh_key: "yes"
+    ssh_key_type: "ed25519"
+    ssh_key_file: ".ssh/id_ed25519"
+
+- name: "Configure SS: Register ssh key"
+  command: cat /var/lib/archivematica/.ssh/id_ed25519.pub
+  register: ssh_key
+
+- name: "Configure SS: Show ssh key"
+  debug: msg={{ ssh_key.stdout_lines }}
+
+# Get id of the associated pipeline
+- name: "Configure SS: Get default pipeline UUID from SS database"
+  mysql_query:
+    login_db: "{{ archivematica_src_ss_db_name }}"
+    login_user: "{{ archivematica_src_ss_db_user }}"
+    login_password: "{{ archivematica_src_ss_db_password }}"
+    login_host: "{{ archivematica_src_ss_db_host }}"
+    query: >
+           SELECT uuid FROM locations_pipeline WHERE remote_name like %(pipeline)s;
+    named_args:
+      pipeline: "%{{ archivematica_src_remote_pipeline }}%"
+  register: __pipeline_uuid_query
+
+- name: "Configure SS: Set pipeline_uuid"
+  set_fact:
+    __pipeline_uuid: "{{ (__pipeline_uuid_query.query_result |flatten | first).uuid }}"
+  when: __pipeline_uuid_query.rowcount[0] > 0
+ 
+# If pipeline_uuid exists, configure the space and locations
+- name: "Configure SS: Configure pipeline local filesystem space and locations"
+  block:
+
+    - name: "Configure SS remote pipeline: Add ssh key to pipeline server"
+      authorized_key:
+        user: "archivematica"
+        state: "present"
+        key: "{{ ssh_key.stdout }}"
+      delegate_to: "{{ archivematica_src_remote_pipeline }}"
+      remote_user: "{{ ansible_ssh_user | default('artefactual') }}"
+
+    - name: "Configure SS remote pipeline: Fetch and add pipeline hostname to .ssh/known_hosts"
+      become: "yes"
+      become_user: "archivematica"
+      known_hosts:
+        name: "{{ archivematica_src_remote_pipeline }}"
+        key: "{{ lookup('pipe', 'ssh-keyscan -H ' + archivematica_src_remote_pipeline) }}"  # Fetch the SSH key automatically
+        path: "~/.ssh/known_hosts"
+
+    - name: "Configure SS remote pipeline: Check if the remote space already exist"
+      uri:
+        url: "{{ archivematica_src_configure_ss_url }}/api/v2/space/?access_protocol=PIPE_FS"
+        headers:
+          Authorization: "ApiKey {{ archivematica_src_configure_ss_user }}:{{ archivematica_src_configure_ss_api_key }}"
+      register: "__space_list"
+
+    - name: "Configure SS remote pipeline: Init remote_hostname var"
+      set_fact:
+        __remote_hostname: "no_pipeline_in_space"
+
+    - name: "Configure SS remote pipeline: Update remote_hostname when exist in space_list"
+      set_fact:
+        __remote_hostname: "{{ item.remote_name }}"
+      when: item.remote_name == archivematica_src_remote_pipeline
+      loop: "{{ __space_list.json.objects }}"
+
+    - name: "Configure SS remote pipeline: Check uuid for local filesystem space"
+      uri:
+        url: "{{ archivematica_src_configure_ss_url }}/api/v2/space/?access_protocol=FS"
+        headers:
+          Authorization: "ApiKey {{ archivematica_src_configure_ss_user }}:{{ archivematica_src_configure_ss_api_key }}"
+      register: "__local_space_list"
+      when: __remote_hostname  !=  archivematica_src_remote_pipeline
+
+    - name: "Configure SS remote pipeline: Set uuid for default filesystem space"
+      set_fact:
+         __local_space_uuid: "{{ __local_space_list.json.objects[0].uuid }}"
+      when: __remote_hostname != archivematica_src_remote_pipeline
+
+    - name: "Configure SS remote pipeline: Disable unused locations on local space "
+      mysql_query:
+        login_db: "{{ archivematica_src_ss_db_name }}"
+        login_user: "{{ archivematica_src_ss_db_user }}"
+        login_password: "{{ archivematica_src_ss_db_password }}"
+        login_host: "{{ archivematica_src_ss_db_host }}"
+        query:
+           - UPDATE locations_location set enabled=0 where purpose = 'CP' and space_id=%(uuid)s
+           - UPDATE locations_location set enabled=0 where purpose = 'BL' and space_id=%(uuid)s
+        named_args:
+          uuid: "{{ __local_space_uuid }}"
+      when: __remote_hostname != archivematica_src_remote_pipeline
+
+    - name: "Configure SS remote pipeline: Add remote space"
+      uri:
+        url: "{{ archivematica_src_configure_ss_url }}/api/v2/space/"
+        headers:
+          Content-Type: "application/json"
+          Authorization: "ApiKey {{ archivematica_src_configure_ss_user }}:{{ archivematica_src_configure_ss_api_key }}"
+        body:
+          access_protocol: "PIPE_FS"
+          path: "/"
+          staging_path: "/var/archivematica/storage_service"
+          remote_name: "{{ archivematica_src_remote_pipeline }}"
+          rsync_password: ""
+          assume_rsync_daemon: "False"
+          remote_user: "archivematica"
+        body_format: json
+        status_code: 201
+        method: POST
+      when: __remote_hostname != archivematica_src_remote_pipeline
+      register: "space_created"
+
+    - name: "Configure SS remote pipeline: Get remote space uuid"
+      set_fact:
+        __space_uuid: "{{ space_created.json.uuid }}"
+      when: __remote_hostname != archivematica_src_remote_pipeline
+
+    - name: "Configure SS remote pipeline: Add custom locations"
+      uri:
+        url: "{{ archivematica_src_configure_ss_url }}/api/v2/location/"
+        headers:
+          Content-Type: "application/json"
+          Authorization: "ApiKey {{ archivematica_src_configure_ss_user }}:{{ archivematica_src_configure_ss_api_key }}"
+        body:
+          pipeline: ["/api/v2/pipeline/{{ __pipeline_uuid }}/"]
+          purpose: "{{ item.location_purpose }}"
+          relative_path: "{{ item.location_path | regex_replace('^\\/', '') }}"
+          description: "{{ item.location_description }}"
+          space: "/api/v2/space/{{ __space_uuid }}/"
+          default: "{{ item.location_default }}"
+        body_format: json
+        status_code: 201
+        method: POST
+      with_items: "{{ archivematica_src_remote_locations }}"
+      tags: "configure-am"
+      when: __remote_hostname != archivematica_src_remote_pipeline
+  when: __pipeline_uuid_query.rowcount[0] > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -353,6 +353,17 @@
     - "amsrc-configure"
   when: "archivematica_src_configure_ss|bool or archivematica_src_configure_dashboard|bool"
 
+
+# Configure remote pipeline spaces
+
+- import_tasks: "configure-remote-pipeline.yml"
+  tags:
+    - "amsrc-remote-pipeline"
+    - "amsrc-configure"
+  when:
+    - archivematica_src_remote_pipeline is defined
+    - archivematica_src_configure_ss|bool
+
 #
 # Configure GPG locations
 #


### PR DESCRIPTION
Prerequesites:

  - archivematica_ss_fqdn_host needs to be defined and different from ansible_archivematica_fqdn
  - am_ss_remote_locations must exist ( an example is available in defaults/main.yml)
  - a group named "dashboard" and including the ansible host for the dashboard must be present in the inventory.