### PR TITLE
Set ownership of virtualenv directories recursively

### DIFF
--- a/tasks/acceptance-tests.yml
+++ b/tasks/acceptance-tests.yml
@@ -34,6 +34,7 @@
     owner: "archivematica"
     group: "archivematica"
     state: "directory"
+    recurse: true
   tags: "amsrc-ss-pydep"
 
 - name: "Install pip dependencies in virtualenv"

--- a/tasks/automation-tools.yml
+++ b/tasks/automation-tools.yml
@@ -26,6 +26,7 @@
     owner: "archivematica"
     group: "archivematica"
     state: "directory"
+    recurse: true
 
 - name: "Install pip dependencies in virtualenv"
   become: "yes"

--- a/tasks/fixity.yml
+++ b/tasks/fixity.yml
@@ -25,6 +25,7 @@
     owner: "archivematica"
     group: "archivematica"
     state: "directory"
+    recurse: true
 
 - name: "Install pip dependencies in virtualenv"
   become: "yes"

--- a/tasks/pipeline-pip-deps.yml
+++ b/tasks/pipeline-pip-deps.yml
@@ -22,6 +22,7 @@
     owner: "archivematica"
     group: "archivematica"
     state: "directory"
+    recurse: true
 
 - name: "Create virtualenv and install pip-tools"
   become: "yes"

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -86,6 +86,7 @@
     owner: "archivematica"
     group: "archivematica"
     state: "directory"
+    recurse: true
   tags: "amsrc-ss-pydep"
 
 - name: "Create virtualenv and install pip-tools"


### PR DESCRIPTION
During upgrades sometimes the `Synchronize requirements` task of the Storage Service fails with `Permission denied` errors like this:

```console
TASK [artefactual.archivematica-qa-src : Synchronize requirements] ************************************************************************************************************************************************************
changed: [am117bigserver]
fatal: [am117jammy]: FAILED! => {"changed": true, "cmd": ["/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/pip-sync", "requirements.txt"], "delta": "0:00:24.668027", "end": "2024-10-30 10:00:51.093155", "msg": "non-zero return code", "rc": 1, "start": "2024-10-30 10:00:26.425128", "stderr": "ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: '__init__.cpython-39.pyc'\nCheck the permissions.\n\nTraceback (most recent call last):\n  File \"/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/pip-sync\", line 8, in <module>\n    sys.exit(cli())\n  File \"/usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages/click/core.py\", line 1157, in __call__\n    return self.main(*args, **kwargs)\n  File \"/usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages/click/core.py\", line 1078, in main\n    rv = self.invoke(ctx)\n  File \"/usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages/click/core.py\", line 1434, in invoke\n    return ctx.invoke(self.callback, **ctx.params)\n  File \"/usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages/click/core.py\", line 783, in invoke\n    return __callback(*args, **kwargs)\n  File \"/usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages/piptools/scripts/sync.py\", line 178, in cli\n    sync.sync(\n  File \"/usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages/piptools/sync.py\", line 248, in sync\n    run(  # nosec\n  File \"/usr/lib/python3.9/subprocess.py\", line 528, in run\n    raise CalledProcessError(retcode, process.args,\nsubprocess.CalledProcessError: Command '['/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python', '-m', 'pip', 'install', '-r', '/tmp/tmp8sky448g']' returned non-zero exit status 1.", "stderr_lines": ["ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: '__init__.cpython-39.pyc'", "Check the permissions.", "", "Traceback (most recent call last):", "  File \"/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/pip-sync\", line 8, in <module>", "    sys.exit(cli())", "  File \"/usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages/click/core.py\", line 1157, in __call__", "    return self.main(*args, **kwargs)", "  File \"/usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages/click/core.py\", line 1078, in main", "    rv = self.invoke(ctx)", "  File \"/usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages/click/core.py\", line 1434, in invoke", "    return ctx.invoke(self.callback, **ctx.params)", "  File \"/usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages/click/core.py\", line 783, in invoke", "    return __callback(*args, **kwargs)", "  File \"/usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages/piptools/scripts/sync.py\", line 178, in cli", "    sync.sync(", "  File \"/usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages/piptools/sync.py\", line 248, in sync", "    run(  # nosec", "  File \"/usr/lib/python3.9/subprocess.py\", line 528, in run", "    raise CalledProcessError(retcode, process.args,", "subprocess.CalledProcessError: Command '['/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python', '-m', 'pip', 'install', '-r', '/tmp/tmp8sky448g']' returned non-zero exit status 1."], "stdout": "Found existing installation: django-shibboleth-remoteuser 0.12\nUninstalling django-shibboleth-remoteuser-0.12:\n  Successfully uninstalled django-shibboleth-remoteuser-0.12\nFound existing installation: oslo.config 9.6.0\nUninstalling oslo.config-9.6.0:\n  Successfully uninstalled oslo.config-9.6.0\nFound existing installation: oslo.i18n 6.4.0\nUninstalling oslo.i18n-6.4.0:\n  Successfully uninstalled oslo.i18n-6.4.0\nFound existing installation: oslo.serialization 5.5.0\nUninstalling oslo.serialization-5.5.0:\n  Successfully uninstalled oslo.serialization-5.5.0\nFound existing installation: oslo.utils 7.3.0\nUninstalling oslo.utils-7.3.0:\n  Successfully uninstalled oslo.utils-7.3.0\nFound existing installation: sword2 0.2.1\nUninstalling sword2-0.2.1:\n  Successfully uninstalled sword2-0.2.1\nFound existing installation: zope.event 5.0\nUninstalling zope.event-5.0:\n  Successfully uninstalled zope.event-5.0\nFound existing installation: zope.interface 7.1.0\nUninstalling zope.interface-7.1.0:\n  Successfully uninstalled zope.interface-7.1.0\nCollecting django-shibboleth-remoteuser@ git+https://github.com/artefactual-labs/django-shibboleth-remoteuser.git@f08a7864d6130416c352981ccf318fff0fd5be58\n  Using cached django_shibboleth_remoteuser-0.12-py3-none-any.whl\nCollecting sword2@ git+https://github.com/artefactual-labs/python-client-sword2.git@619ee44467dcdb2ab75fab16864ea2e4ded7ffe4\n  Using cached sword2-0.2.1-py3-none-any.whl\nCollecting boto3==1.35.49\n  Downloading boto3-1.35.49-py3-none-any.whl (139 kB)\nCollecting botocore==1.35.49\n  Downloading botocore-1.35.49-py3-none-any.whl (12.6 MB)\nCollecting cryptography==43.0.3\n  Downloading cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl (4.0 MB)\nCollecting mysqlclient==2.2.5\n  Downloading mysqlclient-2.2.5.tar.gz (90 kB)\n  Installing build dependencies: started\n  Installing build dependencies: finished with status 'done'\n  Getting requirements to build wheel: started\n  Getting requirements to build wheel: finished with status 'done'\n  Preparing metadata (pyproject.toml): started\n  Preparing metadata (pyproject.toml): finished with status 'done'\nCollecting oslo-config==9.6.0\n  Using cached oslo.config-9.6.0-py3-none-any.whl (132 kB)\nCollecting oslo-i18n==6.4.0\n  Using cached oslo.i18n-6.4.0-py3-none-any.whl (46 kB)\nCollecting oslo-serialization==5.5.0\n  Using cached oslo.serialization-5.5.0-py3-none-any.whl (26 kB)\nCollecting oslo-utils==7.3.0\n  Using cached oslo.utils-7.3.0-py3-none-any.whl (129 kB)\nCollecting setuptools==75.2.0\n  Downloading setuptools-75.2.0-py3-none-any.whl (1.2 MB)\nCollecting zope-event==5.0\n  Using cached zope.event-5.0-py3-none-any.whl (6.8 kB)\nCollecting zope-interface==7.1.1\n  Downloading zope.interface-7.1.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (253 kB)\nRequirement already satisfied: jmespath<2.0.0,>=0.7.1 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from boto3==1.35.49->-r /tmp/tmp8sky448g (line 1)) (1.0.1)\nRequirement already satisfied: s3transfer<0.11.0,>=0.10.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from boto3==1.35.49->-r /tmp/tmp8sky448g (line 1)) (0.10.3)\nRequirement already satisfied: python-dateutil<3.0.0,>=2.1 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from botocore==1.35.49->-r /tmp/tmp8sky448g (line 2)) (2.9.0.post0)\nRequirement already satisfied: urllib3<1.27,>=1.25.4 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from botocore==1.35.49->-r /tmp/tmp8sky448g (line 2)) (1.26.20)\nRequirement already satisfied: cffi>=1.12 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from cryptography==43.0.3->-r /tmp/tmp8sky448g (line 3)) (1.17.1)\nRequirement already satisfied: rfc3986>=1.2.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (2.0.0)\nRequirement already satisfied: PyYAML>=5.1 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (6.0.2)\nRequirement already satisfied: stevedore>=1.20.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (5.3.0)\nRequirement already satisfied: debtcollector>=1.2.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (3.0.0)\nRequirement already satisfied: netaddr>=0.7.18 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (1.3.0)\nRequirement already satisfied: requests>=2.18.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (2.32.3)\nRequirement already satisfied: pbr>=2.0.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-i18n==6.4.0->-r /tmp/tmp8sky448g (line 7)) (6.1.0)\nRequirement already satisfied: tzdata>=2022.4 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-serialization==5.5.0->-r /tmp/tmp8sky448g (line 8)) (2024.2)\nRequirement already satisfied: msgpack>=0.5.2 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-serialization==5.5.0->-r /tmp/tmp8sky448g (line 8)) (1.1.0)\nRequirement already satisfied: netifaces>=0.10.4 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-utils==7.3.0->-r /tmp/tmp8sky448g (line 9)) (0.11.0)\nRequirement already satisfied: packaging>=20.4 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-utils==7.3.0->-r /tmp/tmp8sky448g (line 9)) (24.1)\nRequirement already satisfied: iso8601>=0.1.11 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-utils==7.3.0->-r /tmp/tmp8sky448g (line 9)) (2.1.0)\nRequirement already satisfied: pyparsing>=2.1.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-utils==7.3.0->-r /tmp/tmp8sky448g (line 9)) (3.1.4)\nRequirement already satisfied: httplib2 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from sword2@ git+https://github.com/artefactual-labs/python-client-sword2.git@619ee44467dcdb2ab75fab16864ea2e4ded7ffe4->-r /tmp/tmp8sky448g (line 11)) (0.22.0)\nRequirement already satisfied: lxml in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from sword2@ git+https://github.com/artefactual-labs/python-client-sword2.git@619ee44467dcdb2ab75fab16864ea2e4ded7ffe4->-r /tmp/tmp8sky448g (line 11)) (5.3.0)\nRequirement already satisfied: pycparser in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from cffi>=1.12->cryptography==43.0.3->-r /tmp/tmp8sky448g (line 3)) (2.22)\nRequirement already satisfied: wrapt>=1.7.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from debtcollector>=1.2.0->oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (1.16.0)\nRequirement already satisfied: six>=1.5 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from python-dateutil<3.0.0,>=2.1->botocore==1.35.49->-r /tmp/tmp8sky448g (line 2)) (1.16.0)\nRequirement already satisfied: certifi>=2017.4.17 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from requests>=2.18.0->oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (2024.8.30)\nRequirement already satisfied: charset-normalizer<4,>=2 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from requests>=2.18.0->oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (3.4.0)\nRequirement already satisfied: idna<4,>=2.5 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from requests>=2.18.0->oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (3.10)\nBuilding wheels for collected packages: mysqlclient\n  Building wheel for mysqlclient (pyproject.toml): started\n  Building wheel for mysqlclient (pyproject.toml): finished with status 'done'\n  Created wheel for mysqlclient: filename=mysqlclient-2.2.5-cp39-cp39-linux_x86_64.whl size=124282 sha256=6daae65b8f611e1e84f215ec91705185700be89e5c4bf0ad26c26edc712a3f95\n  Stored in directory: /var/lib/archivematica/.cache/pip/wheels/7b/87/5d/d3d722252d860e98a0ce6887119d22ed7b332d7f9e9b0a43ef\nSuccessfully built mysqlclient\nInstalling collected packages: oslo-i18n, botocore, setuptools, oslo-utils, zope-interface, zope-event, sword2, oslo-serialization, oslo-config, mysqlclient, django-shibboleth-remoteuser, cryptography, boto3\n  Attempting uninstall: botocore\n    Found existing installation: botocore 1.35.37\n    Uninstalling botocore-1.35.37:\n      Successfully uninstalled botocore-1.35.37\n  Attempting uninstall: setuptools\n    Found existing installation: setuptools 75.1.0\n    Uninstalling setuptools-75.1.0:\n      Successfully uninstalled setuptools-75.1.0", "stdout_lines": ["Found existing installation: django-shibboleth-remoteuser 0.12", "Uninstalling django-shibboleth-remoteuser-0.12:", "  Successfully uninstalled django-shibboleth-remoteuser-0.12", "Found existing installation: oslo.config 9.6.0", "Uninstalling oslo.config-9.6.0:", "  Successfully uninstalled oslo.config-9.6.0", "Found existing installation: oslo.i18n 6.4.0", "Uninstalling oslo.i18n-6.4.0:", "  Successfully uninstalled oslo.i18n-6.4.0", "Found existing installation: oslo.serialization 5.5.0", "Uninstalling oslo.serialization-5.5.0:", "  Successfully uninstalled oslo.serialization-5.5.0", "Found existing installation: oslo.utils 7.3.0", "Uninstalling oslo.utils-7.3.0:", "  Successfully uninstalled oslo.utils-7.3.0", "Found existing installation: sword2 0.2.1", "Uninstalling sword2-0.2.1:", "  Successfully uninstalled sword2-0.2.1", "Found existing installation: zope.event 5.0", "Uninstalling zope.event-5.0:", "  Successfully uninstalled zope.event-5.0", "Found existing installation: zope.interface 7.1.0", "Uninstalling zope.interface-7.1.0:", "  Successfully uninstalled zope.interface-7.1.0", "Collecting django-shibboleth-remoteuser@ git+https://github.com/artefactual-labs/django-shibboleth-remoteuser.git@f08a7864d6130416c352981ccf318fff0fd5be58", "  Using cached django_shibboleth_remoteuser-0.12-py3-none-any.whl", "Collecting sword2@ git+https://github.com/artefactual-labs/python-client-sword2.git@619ee44467dcdb2ab75fab16864ea2e4ded7ffe4", "  Using cached sword2-0.2.1-py3-none-any.whl", "Collecting boto3==1.35.49", "  Downloading boto3-1.35.49-py3-none-any.whl (139 kB)", "Collecting botocore==1.35.49", "  Downloading botocore-1.35.49-py3-none-any.whl (12.6 MB)", "Collecting cryptography==43.0.3", "  Downloading cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl (4.0 MB)", "Collecting mysqlclient==2.2.5", "  Downloading mysqlclient-2.2.5.tar.gz (90 kB)", "  Installing build dependencies: started", "  Installing build dependencies: finished with status 'done'", "  Getting requirements to build wheel: started", "  Getting requirements to build wheel: finished with status 'done'", "  Preparing metadata (pyproject.toml): started", "  Preparing metadata (pyproject.toml): finished with status 'done'", "Collecting oslo-config==9.6.0", "  Using cached oslo.config-9.6.0-py3-none-any.whl (132 kB)", "Collecting oslo-i18n==6.4.0", "  Using cached oslo.i18n-6.4.0-py3-none-any.whl (46 kB)", "Collecting oslo-serialization==5.5.0", "  Using cached oslo.serialization-5.5.0-py3-none-any.whl (26 kB)", "Collecting oslo-utils==7.3.0", "  Using cached oslo.utils-7.3.0-py3-none-any.whl (129 kB)", "Collecting setuptools==75.2.0", "  Downloading setuptools-75.2.0-py3-none-any.whl (1.2 MB)", "Collecting zope-event==5.0", "  Using cached zope.event-5.0-py3-none-any.whl (6.8 kB)", "Collecting zope-interface==7.1.1", "  Downloading zope.interface-7.1.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (253 kB)", "Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from boto3==1.35.49->-r /tmp/tmp8sky448g (line 1)) (1.0.1)", "Requirement already satisfied: s3transfer<0.11.0,>=0.10.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from boto3==1.35.49->-r /tmp/tmp8sky448g (line 1)) (0.10.3)", "Requirement already satisfied: python-dateutil<3.0.0,>=2.1 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from botocore==1.35.49->-r /tmp/tmp8sky448g (line 2)) (2.9.0.post0)", "Requirement already satisfied: urllib3<1.27,>=1.25.4 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from botocore==1.35.49->-r /tmp/tmp8sky448g (line 2)) (1.26.20)", "Requirement already satisfied: cffi>=1.12 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from cryptography==43.0.3->-r /tmp/tmp8sky448g (line 3)) (1.17.1)", "Requirement already satisfied: rfc3986>=1.2.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (2.0.0)", "Requirement already satisfied: PyYAML>=5.1 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (6.0.2)", "Requirement already satisfied: stevedore>=1.20.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (5.3.0)", "Requirement already satisfied: debtcollector>=1.2.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (3.0.0)", "Requirement already satisfied: netaddr>=0.7.18 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (1.3.0)", "Requirement already satisfied: requests>=2.18.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (2.32.3)", "Requirement already satisfied: pbr>=2.0.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-i18n==6.4.0->-r /tmp/tmp8sky448g (line 7)) (6.1.0)", "Requirement already satisfied: tzdata>=2022.4 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-serialization==5.5.0->-r /tmp/tmp8sky448g (line 8)) (2024.2)", "Requirement already satisfied: msgpack>=0.5.2 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-serialization==5.5.0->-r /tmp/tmp8sky448g (line 8)) (1.1.0)", "Requirement already satisfied: netifaces>=0.10.4 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-utils==7.3.0->-r /tmp/tmp8sky448g (line 9)) (0.11.0)", "Requirement already satisfied: packaging>=20.4 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-utils==7.3.0->-r /tmp/tmp8sky448g (line 9)) (24.1)", "Requirement already satisfied: iso8601>=0.1.11 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-utils==7.3.0->-r /tmp/tmp8sky448g (line 9)) (2.1.0)", "Requirement already satisfied: pyparsing>=2.1.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from oslo-utils==7.3.0->-r /tmp/tmp8sky448g (line 9)) (3.1.4)", "Requirement already satisfied: httplib2 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from sword2@ git+https://github.com/artefactual-labs/python-client-sword2.git@619ee44467dcdb2ab75fab16864ea2e4ded7ffe4->-r /tmp/tmp8sky448g (line 11)) (0.22.0)", "Requirement already satisfied: lxml in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from sword2@ git+https://github.com/artefactual-labs/python-client-sword2.git@619ee44467dcdb2ab75fab16864ea2e4ded7ffe4->-r /tmp/tmp8sky448g (line 11)) (5.3.0)", "Requirement already satisfied: pycparser in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from cffi>=1.12->cryptography==43.0.3->-r /tmp/tmp8sky448g (line 3)) (2.22)", "Requirement already satisfied: wrapt>=1.7.0 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from debtcollector>=1.2.0->oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (1.16.0)", "Requirement already satisfied: six>=1.5 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from python-dateutil<3.0.0,>=2.1->botocore==1.35.49->-r /tmp/tmp8sky448g (line 2)) (1.16.0)", "Requirement already satisfied: certifi>=2017.4.17 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from requests>=2.18.0->oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (2024.8.30)", "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from requests>=2.18.0->oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (3.4.0)", "Requirement already satisfied: idna<4,>=2.5 in /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python3.9/site-packages (from requests>=2.18.0->oslo-config==9.6.0->-r /tmp/tmp8sky448g (line 6)) (3.10)", "Building wheels for collected packages: mysqlclient", "  Building wheel for mysqlclient (pyproject.toml): started", "  Building wheel for mysqlclient (pyproject.toml): finished with status 'done'", "  Created wheel for mysqlclient: filename=mysqlclient-2.2.5-cp39-cp39-linux_x86_64.whl size=124282 sha256=6daae65b8f611e1e84f215ec91705185700be89e5c4bf0ad26c26edc712a3f95", "  Stored in directory: /var/lib/archivematica/.cache/pip/wheels/7b/87/5d/d3d722252d860e98a0ce6887119d22ed7b332d7f9e9b0a43ef", "Successfully built mysqlclient", "Installing collected packages: oslo-i18n, botocore, setuptools, oslo-utils, zope-interface, zope-event, sword2, oslo-serialization, oslo-config, mysqlclient, django-shibboleth-remoteuser, cryptography, boto3", "  Attempting uninstall: botocore", "    Found existing installation: botocore 1.35.37", "    Uninstalling botocore-1.35.37:", "      Successfully uninstalled botocore-1.35.37", "  Attempting uninstall: setuptools", "    Found existing installation: setuptools 75.1.0", "    Uninstalling setuptools-75.1.0:", "      Successfully uninstalled setuptools-75.1.0"]}
```

This PR ensures that the `archivematica` user and group have ownership of the virtual environment directories recursively before executing any `pip` related command.