### PR TITLE
Use systemd-creds for managing secrets

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -294,3 +294,5 @@ archivematica_src_remote_locations:
   - { location_purpose: "BL", location_path: "/var/archivematica/sharedDirectory/www/AIPsStore/transferBacklog", location_description: "Remote transfer backlog", location_default: "true" }
 #  - { location_purpose: "TS", location_path: "/home", location_description: "Remote transfer source", location_default: "true" }
 
+# Use systemd credentials
+archivematica_src_systemd_credentials: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -278,6 +278,11 @@ archivematica_src_syslog_mcpserver_level: "DEBUG"
 #  - { location_purpose: "RP", location_path: "/replicator", location_description: "Replicator location", location_default: "false", location_replication_from: "AipStore" }
 #  - { location_purpose: "AS", location_path: "/aipstore", location_description: "AipStore", location_default: "true" }
 #  - { location_purpose: "TS", location_path: "/transfer-source/", location_description: "Transfer Source", location_default: "false" }
+#  - { location_purpose: "AS", location_description: "Store AIP in standard Archivematica Directory", location_enabled: "false" }
+#  - { location_purpose: "DS", location_description: "Store DIP in standard Archivematica Directory", location_enabled: "false" }
+#  - { location_purpose: "TS", location_description: "Default transfer source", location_enabled: "false" }
+#  - { location_purpose: "BL", location_description: "Default transfer backlog", location_enabled: "false" }
+
 
 
 # Configure Remote pipeline

--- a/tasks/configure-aipstores.yml
+++ b/tasks/configure-aipstores.yml
@@ -1,0 +1,82 @@
+---
+## Configure default locations
+# Get id of the associated pipeline
+- name: "Configure SS: Get default pipeline UUID from SS database"
+  mysql_query:
+    login_db: "{{ archivematica_src_ss_db_name }}"
+    login_user: "{{ archivematica_src_ss_db_user }}"
+    login_password: "{{ archivematica_src_ss_db_password }}"
+    login_host: "{{ archivematica_src_ss_db_host }}"
+    query: >
+           SELECT uuid FROM locations_pipeline WHERE remote_name like %(pipeline)s;
+    named_args:
+      pipeline: "%{{ archivematica_src_remote_pipeline }}%"
+  register: __pipeline_uuid_query
+
+- name: "Configure SS: Set pipeline_uuid"
+  set_fact:
+    __pipeline_uuid: "{{ (__pipeline_uuid_query.query_result |flatten | first).uuid }}"
+  when: __pipeline_uuid_query.rowcount[0] > 0
+ 
+# If pipeline_uuid exists, configure the space and locations
+- name: "Configure SS: Configure pipeline local filesystem space and locations"
+  block:
+    - name: "Configure SS default spaces: Check if the  space already exist"
+      uri:
+        url: "{{ archivematica_src_configure_ss_url }}/api/v2/space/?access_protocol=FS"
+        headers:
+          Authorization: "ApiKey {{ archivematica_src_configure_ss_user }}:{{ archivematica_src_configure_ss_api_key }}"
+      register: "__space_list"
+
+
+    - name: "Configure SS remote pipeline: Check uuid for local filesystem space"
+      uri:
+        url: "{{ archivematica_src_configure_ss_url }}/api/v2/space/?access_protocol=FS"
+        headers:
+          Authorization: "ApiKey {{ archivematica_src_configure_ss_user }}:{{ archivematica_src_configure_ss_api_key }}"
+      register: "__local_space_list"
+
+    - name: "Configure SS remote pipeline: Set uuid for default filesystem space"
+      set_fact:
+         __local_space_uuid: "{{ __local_space_list.json.objects[0].uuid }}"
+    - name: "Configure AM: get all TS descriptions from SS database"
+      become: "yes"
+      command:  mysql {{ archivematica_src_ss_db_name }} -Ns -e "select description from locations_location;"
+      register: location_descriptions
+      tags: "configure-am"
+
+    - name: "Configure SS default locations: Add custom locations"
+      uri:
+        url: "{{ archivematica_src_configure_ss_url }}/api/v2/location/"
+        headers:
+          Content-Type: "application/json"
+          Authorization: "ApiKey {{ archivematica_src_configure_ss_user }}:{{ archivematica_src_configure_ss_api_key }}"
+        body:
+          pipeline: ["/api/v2/pipeline/{{ __pipeline_uuid }}/"]
+          purpose: "{{ item.location_purpose }}"
+          relative_path: "{{ item.location_path | regex_replace('^\\/', '') }}"
+          description: "{{ item.location_description }}"
+          space: "/api/v2/space/{{ __local_space_uuid }}/"
+          default: "{{ item.location_default }}"
+        body_format: json
+        status_code: 201
+        method: POST
+      with_items: "{{ am_ss_default_locations }}"
+      when: not location_descriptions.stdout | join('') | regex_search( '(^|\n)'+item.location_description+'(\n|$)' )
+      tags: "configure-am"
+    - name: "Configure SS: configure replication locations "
+      mysql_query:
+        login_db: "{{ archivematica_src_ss_db_name }}"
+        login_user: "{{ archivematica_src_ss_db_user }}"
+        login_password: "{{ archivematica_src_ss_db_password }}"
+        login_host: "{{ archivematica_src_ss_db_host }}"
+        query:
+           - INSERT IGNORE INTO locations_location_replicators(from_location_id,to_location_id) VALUES ((SELECT id FROM locations_location where description = %(aipstore)s and purpose = "AS"),(SELECT id FROM locations_location where description = %(replica)s and purpose = "RP" ));
+        named_args:
+          aipstore: "{{ item.location_replication_from }}"
+          replica: "{{ item.location_description }}"
+      when:
+        - item.location_replication_from is defined
+      with_items:
+        - "{{ am_ss_default_locations }}"
+  when: __pipeline_uuid_query.rowcount[0] > 0

--- a/tasks/configure-aipstores.yml
+++ b/tasks/configure-aipstores.yml
@@ -79,4 +79,19 @@
         - item.location_replication_from is defined
       with_items:
         - "{{ am_ss_default_locations }}"
+    - name: "Configure SS: disable unused locations "
+      mysql_query:
+        login_db: "{{ archivematica_src_ss_db_name }}"
+        login_user: "{{ archivematica_src_ss_db_user }}"
+        login_password: "{{ archivematica_src_ss_db_password }}"
+        login_host: "{{ archivematica_src_ss_db_host }}"
+        query:
+          - UPDATE locations_location SET enabled=0 WHERE description = %(aipstore)s ;
+        named_args:
+          aipstore: "{{ item.location_description }}"
+      when:
+        - item.location_enabled is defined
+      with_items:
+        - "{{ am_ss_default_locations }}"
+
   when: __pipeline_uuid_query.rowcount[0] > 0

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -132,7 +132,9 @@
     pythonpath: "{{ archivematica_src_am_common_app }}"
     virtualenv: "{{ archivematica_src_am_dashboard_virtualenv }}"
   environment: "{{ archivematica_src_am_dashboard_environment }}"
-  when: archivematica_src_configure_dashboard|bool and dashboard_user.stdout == "" and dashboard_ss_url.stdout == ""
+  when:
+    - archivematica_src_configure_dashboard|bool
+    - (dashboard_user.stdout == "" and dashboard_ss_url.stdout == "") or ( dashboard_ss_url.stdout != archivematica_src_configure_ss_url)
 
 
 #
@@ -262,61 +264,3 @@
     - archivematica_src_configure_dashboard|bool
     - archivematica_src_configure_fprule is defined
 
-- name: "Configure locations"
-  block:
-    # Get id of the first registered pipeline (id=1)
-    - name: "Configure AM: get default pipeline UUID from SS database"
-      become: "yes"
-      command:  mysql {{ archivematica_src_ss_db_name }} -Ns -e "select uuid from locations_pipeline where id='1';"
-      register: pipeline_uuid
-      tags: "configure-am"
-
-    # Gets the uuid of the first registered space (id=1)
-    - name: "Configure AM: get default Space UUID from SS database"
-      become: "yes"
-      command:  mysql {{ archivematica_src_ss_db_name }} -Ns -e "select uuid from locations_space where id='1';"
-      register: space_uuid
-      tags: "configure-am"
-
-    - name: "Configure AM: get all TS descriptions from SS database"
-      become: "yes"
-      command:  mysql {{ archivematica_src_ss_db_name }} -Ns -e "select description from locations_location;"
-      register: location_descriptions
-      tags: "configure-am"
-
-    - name: "Configure SS: add custom locations"
-      uri:
-        url: "{{ archivematica_src_configure_ss_url }}/api/v2/location/"
-        headers:
-          Content-Type: "application/json"
-          Authorization: "ApiKey {{ archivematica_src_configure_ss_user }}:{{ archivematica_src_configure_ss_api_key }}"
-        body:
-          pipeline: ["/api/v2/pipeline/{{ pipeline_uuid.stdout }}/"]
-          purpose: "{{ item.location_purpose }}"
-          relative_path: "{{ item.location_path | regex_replace('^\\/', '') }}"
-          description: "{{ item.location_description }}"
-          space: "/api/v2/space/{{ space_uuid.stdout }}/"
-          default: "{{ item.location_default }}"
-        body_format: json
-        status_code: 201
-        method: POST
-      when: not location_descriptions.stdout | join('') | regex_search( '(^|\n)'+item.location_description+'(\n|$)' )
-      with_items: "{{ am_ss_default_locations }}"
-      tags: "configure-am"
-
-    - name: "Configure SS: configure replication locations "
-      mysql_query:
-        login_db: "{{ archivematica_src_ss_db_name }}"
-        login_user: "{{ archivematica_src_ss_db_user }}"
-        login_password: "{{ archivematica_src_ss_db_password }}"
-        login_host: "{{ archivematica_src_ss_db_host }}"
-        query:
-           - INSERT IGNORE INTO locations_location_replicators(from_location_id,to_location_id) VALUES ((SELECT id FROM locations_location where description = %(aipstore)s and purpose = "AS"),(SELECT id FROM locations_location where description = %(replica)s and purpose = "RP" ));
-        named_args:
-          aipstore: "{{ item.location_replication_from }}"
-          replica: "{{ item.location_description }}"
-      when:
-        - item.location_replication_from is defined
-      with_items:
-        - "{{ am_ss_default_locations }}"
-  when: am_ss_default_locations is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -354,6 +354,13 @@
   when: "archivematica_src_configure_ss|bool or archivematica_src_configure_dashboard|bool"
 
 
+- import_tasks: "configure-aipstores.yml"
+  tags:
+    - "amsrc-configure"
+  when:
+    - archivematica_src_configure_ss|bool
+
+
 # Configure remote pipeline spaces
 
 - import_tasks: "configure-remote-pipeline.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -113,7 +113,7 @@
   - name: "Include common-RHEL.yml for RHEL"
     import_tasks: "common-RHEL.yml"
     when:
-      - "ansible_distribution == 'RedHat'"
+      - "ansible_os_family in ['RedHat','Rocky']"
 
   # Not using package in next task because it is slower than apt or yum modules.
   # The package module is not installing the every list of packages at the same time

--- a/tasks/pipeline-environment.yml
+++ b/tasks/pipeline-environment.yml
@@ -54,6 +54,29 @@
       ARCHIVEMATICA_MCPSERVER_CLIENT_PASSWORD: "{{ archivematica_src_am_db_password }}"
   when: archivematica_src_systemd_credentials|bool
 
+- name: "Configure single MCPClients secure credentials"
+  include: systemd-creds.yml
+  vars:
+    service: archivematica-mcp-client
+    secret_name: mcpc
+    credentials:
+      ARCHIVEMATICA_MCPCLIENT_CLIENT_PASSWORD: "{{ archivematica_src_am_db_password }}"
+  when:
+    - archivematica_src_systemd_credentials|bool
+    - archivematica_src_am_mcpclient_instances == 1
+
+- name: "Configure multi MCPClients secure credentials"
+  include: systemd-creds.yml
+  vars:
+    service: archivematica-mcp-client-{{ '%1d' | format(item) }}
+    secret_name: mcpc
+    credentials:
+      ARCHIVEMATICA_MCPCLIENT_CLIENT_PASSWORD: "{{ archivematica_src_am_db_password }}"
+  loop: "{{ range(1, archivematica_src_am_mcpclient_instances|int  + 1, 1)|list }}"
+  when:
+    - archivematica_src_systemd_credentials|bool
+    - archivematica_src_am_mcpclient_instances > 1
+
 
 - name: "Configure environment vars"
   template:

--- a/tasks/pipeline-environment.yml
+++ b/tasks/pipeline-environment.yml
@@ -36,7 +36,7 @@
 
 
 - name: "Configure dashboard secure credentials"
-  include: systemd-creds.yml
+  include_tasks: systemd-creds.yml
   vars:
     service: archivematica-dashboard
     secret_name: dashboard
@@ -46,7 +46,7 @@
   when: archivematica_src_systemd_credentials|bool
 
 - name: "Configure MCPServer secure credentials"
-  include: systemd-creds.yml
+  include_tasks: systemd-creds.yml
   vars:
     service: archivematica-mcp-server
     secret_name: mcps
@@ -55,7 +55,7 @@
   when: archivematica_src_systemd_credentials|bool
 
 - name: "Configure single MCPClients secure credentials"
-  include: systemd-creds.yml
+  include_tasks: systemd-creds.yml
   vars:
     service: archivematica-mcp-client
     secret_name: mcpc
@@ -66,7 +66,7 @@
     - archivematica_src_am_mcpclient_instances == 1
 
 - name: "Configure multi MCPClients secure credentials"
-  include: systemd-creds.yml
+  include_tasks: systemd-creds.yml
   vars:
     service: archivematica-mcp-client-{{ '%1d' | format(item) }}
     secret_name: mcpc

--- a/tasks/pipeline-environment.yml
+++ b/tasks/pipeline-environment.yml
@@ -33,6 +33,28 @@
     - "archivematica_src_reset_shareddir|bool or archivematica_src_reset_am_all|bool"
     - "archivematica_src_install_automationtools|bool"
 
+
+
+- name: "Configure dashboard secure credentials"
+  include: systemd-creds.yml
+  vars:
+    service: archivematica-dashboard
+    secret_name: dashboard
+    credentials:
+      ARCHIVEMATICA_DASHBOARD_CLIENT_PASSWORD: "{{ archivematica_src_am_db_password }}"
+      ARCHIVEMATICA_DASHBOARD_DASHBOARD_DJANGO_SECRET_KEY: "{{ archivematica_src_am_django_secret_key }}"
+  when: archivematica_src_systemd_credentials|bool
+
+- name: "Configure MCPServer secure credentials"
+  include: systemd-creds.yml
+  vars:
+    service: archivematica-mcp-server
+    secret_name: mcps
+    credentials:
+      ARCHIVEMATICA_MCPSERVER_CLIENT_PASSWORD: "{{ archivematica_src_am_db_password }}"
+  when: archivematica_src_systemd_credentials|bool
+
+
 - name: "Configure environment vars"
   template:
     src: "{{ item.src }}"

--- a/tasks/ss-osconf.yml
+++ b/tasks/ss-osconf.yml
@@ -11,7 +11,7 @@
     - ansible_service_mgr == "systemd"
 
 - name: "Include systemd-creds config"
-  include: systemd-creds.yml
+  include_tasks: systemd-creds.yml
   vars:
     service: archivematica-storage-service
     secret_name: ss

--- a/tasks/ss-osconf.yml
+++ b/tasks/ss-osconf.yml
@@ -10,6 +10,16 @@
   when:
     - ansible_service_mgr == "systemd"
 
+- name: "Include systemd-creds config"
+  include: systemd-creds.yml
+  vars:
+    service: archivematica-storage-service
+    secret_name: ss
+    credentials:
+      SS_DB_URL: "mysql://{{ archivematica_src_ss_db_user }}:{{ archivematica_src_ss_db_password }}@{{ archivematica_src_ss_db_host }}:{{ archivematica_src_ss_db_port }}/{{ archivematica_src_ss_db_name }}"
+      DJANGO_SECRET_KEY: "{{ archivematica_src_ss_django_secret_key }}"
+  when: archivematica_src_systemd_credentials|bool
+
 - name: "Add storage service gunicorn systemd env file"
   template:
     src: "etc/sysconfig/archivematica-storage-service.j2"

--- a/tasks/systemd-creds.yml
+++ b/tasks/systemd-creds.yml
@@ -1,0 +1,25 @@
+- name: "Set fact with secure elements"
+  set_fact:
+    secret: |
+       {% for key, value in credentials.items() %}
+       {{ key }}={{ value }}
+       {% endfor %}
+  no_log: true
+
+- name: Register secure credential
+  shell: echo "{{ secret }}" | systemd-creds encrypt -p --name={{ secret_name }} - -
+  register: secured_credentials
+  no_log: true
+
+- name: "Create override dir"
+  file:
+    path: /etc/systemd/system/{{ service }}.service.d/
+    state: directory
+
+- name: "Template override file"
+  template:
+    src: etc/systemd/system/override.conf.j2
+    dest: /etc/systemd/system/{{ service }}.service.d/override.conf
+
+    
+

--- a/templates/etc/sysconfig/archivematica-dashboard.j2
+++ b/templates/etc/sysconfig/archivematica-dashboard.j2
@@ -6,7 +6,11 @@ LC_ALL="en_US.UTF-8"
 LC_LANG="en_US.UTF-8"
 
 {% for key, value in archivematica_src_am_dashboard_environment.items() %}
+{% if (archivematica_src_systemd_credentials)  %}
 {% if (key != "ARCHIVEMATICA_DASHBOARD_CLIENT_PASSWORD") and (key != "ARCHIVEMATICA_DASHBOARD_DASHBOARD_DJANGO_SECRET_KEY" ) %}
+{{ key }}={{ value }}
+{% endif %}
+{% else %}
 {{ key }}={{ value }}
 {% endif %}
 {% endfor %}

--- a/templates/etc/sysconfig/archivematica-dashboard.j2
+++ b/templates/etc/sysconfig/archivematica-dashboard.j2
@@ -6,5 +6,7 @@ LC_ALL="en_US.UTF-8"
 LC_LANG="en_US.UTF-8"
 
 {% for key, value in archivematica_src_am_dashboard_environment.items() %}
+{% if (key != "ARCHIVEMATICA_DASHBOARD_CLIENT_PASSWORD") and (key != "ARCHIVEMATICA_DASHBOARD_DASHBOARD_DJANGO_SECRET_KEY" ) %}
 {{ key }}={{ value }}
+{% endif %}
 {% endfor %}

--- a/templates/etc/sysconfig/archivematica-mcp-client.j2
+++ b/templates/etc/sysconfig/archivematica-mcp-client.j2
@@ -7,7 +7,9 @@ LC_ALL="en_US.UTF-8"
 LC_LANG="en_US.UTF-8"
 
 {% for key, value in archivematica_src_am_mcpclient_environment.items() %}
+{% if (key != "ARCHIVEMATICA_MCPCLIENT_CLIENT_PASSWORD") %}
 {{ key }}={{ value }}
+{% endif %}
 {% endfor %}
 
 {% if clamav_uses_file_socket is not defined or archivematica_src_mcpclient_clamav_use_tcp|bool %}

--- a/templates/etc/sysconfig/archivematica-mcp-client.j2
+++ b/templates/etc/sysconfig/archivematica-mcp-client.j2
@@ -7,7 +7,11 @@ LC_ALL="en_US.UTF-8"
 LC_LANG="en_US.UTF-8"
 
 {% for key, value in archivematica_src_am_mcpclient_environment.items() %}
+{% if (archivematica_src_systemd_credentials)  %}
 {% if (key != "ARCHIVEMATICA_MCPCLIENT_CLIENT_PASSWORD") %}
+{{ key }}={{ value }}
+{% endif %}
+{% else %}
 {{ key }}={{ value }}
 {% endif %}
 {% endfor %}

--- a/templates/etc/sysconfig/archivematica-mcp-server.j2
+++ b/templates/etc/sysconfig/archivematica-mcp-server.j2
@@ -6,7 +6,11 @@ LC_ALL="en_US.UTF-8"
 LC_LANG="en_US.UTF-8"
 
 {% for key, value in archivematica_src_am_mcpserver_environment.items() %}
+{% if (archivematica_src_systemd_credentials)  %}
 {% if (key != "ARCHIVEMATICA_MCPSERVER_CLIENT_PASSWORD") %}
+{{ key }}={{ value }}
+{% endif %}
+{% else %}
 {{ key }}={{ value }}
 {% endif %}
 {% endfor %}

--- a/templates/etc/sysconfig/archivematica-mcp-server.j2
+++ b/templates/etc/sysconfig/archivematica-mcp-server.j2
@@ -6,5 +6,7 @@ LC_ALL="en_US.UTF-8"
 LC_LANG="en_US.UTF-8"
 
 {% for key, value in archivematica_src_am_mcpserver_environment.items() %}
+{% if (key != "ARCHIVEMATICA_MCPSERVER_CLIENT_PASSWORD") %}
 {{ key }}={{ value }}
+{% endif %}
 {% endfor %}

--- a/templates/etc/sysconfig/archivematica-storage-service.j2
+++ b/templates/etc/sysconfig/archivematica-storage-service.j2
@@ -5,7 +5,11 @@ LC_ALL="en_US.UTF-8"
 LC_LANG="en_US.UTF-8"
 
 {% for key, value in archivematica_src_ss_environment.items() %}
+{% if (archivematica_src_systemd_credentials)  %}
 {% if (key != "SS_DB_URL") and (key != "DJANGO_SECRET_KEY" ) %}
+{{ key }}={{ value }}
+{% endif %}
+{% else %}
 {{ key }}={{ value }}
 {% endif %}
 {% endfor %}

--- a/templates/etc/sysconfig/archivematica-storage-service.j2
+++ b/templates/etc/sysconfig/archivematica-storage-service.j2
@@ -5,5 +5,7 @@ LC_ALL="en_US.UTF-8"
 LC_LANG="en_US.UTF-8"
 
 {% for key, value in archivematica_src_ss_environment.items() %}
+{% if (key != "SS_DB_URL") and (key != "DJANGO_SECRET_KEY" ) %}
 {{ key }}={{ value }}
+{% endif %}
 {% endfor %}

--- a/templates/etc/systemd/system/archivematica-dashboard.service.j2
+++ b/templates/etc/systemd/system/archivematica-dashboard.service.j2
@@ -18,7 +18,11 @@ SyslogIdentifier=DashboardStdout
 SyslogFacility={{ archivematica_src_syslog_dashboard_facility }}
 {% endif %}
 WorkingDirectory={{ archivematica_src_am_dashboard_app }}
+{% if archivematica_src_systemd_credentials|bool %}
+ExecStart=sh -c 'export $(cat $SECRETS); {{ dashboard_gunicorn_path }} --config {{ archivematica_src_am_dashboard_gunicorn_config }} wsgi:application'
+{% else %}
 ExecStart={{ dashboard_gunicorn_path }} --config {{ archivematica_src_am_dashboard_gunicorn_config }} wsgi:application
+{% endif %}
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true

--- a/templates/etc/systemd/system/archivematica-mcp-client.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-client.service.j2
@@ -21,7 +21,11 @@ StandardError=syslog
 SyslogIdentifier=MCPClientStdout
 SyslogFacility={{ archivematica_src_syslog_mcpclient_facility }}
 {% endif %}
+{% if archivematica_src_systemd_credentials|bool %}
+ExecStart=sh -c 'export $(cat $SECRETS); {{ archivematica_src_am_mcpclient_virtualenv }}/bin/python {{ archivematica_src_am_mcpclient_app }}/archivematicaClient.py'
+{% else %}
 ExecStart={{ archivematica_src_am_mcpclient_virtualenv }}/bin/python {{ archivematica_src_am_mcpclient_app }}/archivematicaClient.py
+{% endif %}
 Restart=always
 RestartSec=30
 

--- a/templates/etc/systemd/system/archivematica-mcp-server.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-server.service.j2
@@ -15,7 +15,11 @@ StandardError=syslog
 SyslogIdentifier=MCPServerStdout
 SyslogFacility={{ archivematica_src_syslog_mcpserver_facility }}
 {% endif %}
+{% if archivematica_src_systemd_credentials|bool %}
+ExecStart=sh -c 'export $(cat $SECRETS); {{ archivematica_src_am_mcpserver_virtualenv }}/bin/python {{ archivematica_src_am_mcpserver_app }}/archivematicaMCP.py'
+{% else %}
 ExecStart={{ archivematica_src_am_mcpserver_virtualenv }}/bin/python {{ archivematica_src_am_mcpserver_app }}/archivematicaMCP.py
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/etc/systemd/system/archivematica-storage-service.service.j2
+++ b/templates/etc/systemd/system/archivematica-storage-service.service.j2
@@ -17,7 +17,11 @@ SyslogFacility={{ archivematica_src_syslog_storageservice_facility }}
 {% endif %}
 
 WorkingDirectory={{ archivematica_src_ss_app }}
+{% if archivematica_src_systemd_credentials|bool %}
+ExecStart=sh -c 'export $(cat $SECRETS); {{ archivematica_src_ss_virtualenv }}/bin/gunicorn --config {{ archivematica_src_ss_gunicorn_config }} storage_service.wsgi:application'
+{% else %}
 ExecStart={{ archivematica_src_ss_virtualenv }}/bin/gunicorn --config {{ archivematica_src_ss_gunicorn_config }} storage_service.wsgi:application
+{% endif %}
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true

--- a/templates/etc/systemd/system/override.conf.j2
+++ b/templates/etc/systemd/system/override.conf.j2
@@ -1,0 +1,7 @@
+[Service]
+
+
+
+{{secured_credentials.stdout }}
+
+Environment=SECRETS=%d/{{ secret_name }}

--- a/templates/etc/systemd/system/override.conf.j2
+++ b/templates/etc/systemd/system/override.conf.j2
@@ -1,6 +1,5 @@
 [Service]
-
-
+# Load secure credentials for {{ service }}
 
 {{secured_credentials.stdout }}
 


### PR DESCRIPTION

When ```archivematica_src_systemd_credentials```  is set to true this will:

 - Remove configuration secrets from the default environment vars
 - Properly encrypt secrets using [systemd-creds](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html#encrypt%20input%7C-%20output%7C-)
 - Configure services to load the secrets provided by systemd

The approach is based on https://systemd.io/CREDENTIALS/
