### PR TITLE
Add systemctl reset-failed for fits-nailgun

### DIFF
--- a/tasks/fits.yml
+++ b/tasks/fits.yml
@@ -16,6 +16,10 @@
     enabled: false
   when: service_status.rc == 0
 
+- name: "Reset failed state for fits-nailgun service"
+  command: "systemctl reset-failed fits-nailgun"
+  when: service_status.rc == 0
+
 - name: "Uninstall FITS and its dependencies"
   package:
     name:


### PR DESCRIPTION
For any reason, the status of the deleted service is failed, after running the playbook and removing fits:

```
root@XXXX:~# systemctl | grep -i failed
● fits-nailgun.service           loaded failed     failed    FITS Nailgun server
```

Adding this command will reset the status of that deleted service.