### PR TITLE
Install AM and SS source as Python packages

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -59,16 +59,16 @@
     - "archivematica_src_configure_ss|bool"
 
 - name: "Create SS superuser"
-  django_manage:
-    command: > 
-      create_user 
-      --username="{{ archivematica_src_configure_ss_user }}"
-      --password="{{ archivematica_src_configure_ss_password }}" 
-      --email="{{ archivematica_src_configure_ss_email }}"
-      --api-key="{{ archivematica_src_configure_ss_api_key }}" 
-      --superuser
-    app_path: "{{ archivematica_src_ss_app }}"
-    virtualenv: "{{ archivematica_src_ss_virtualenv }}"
+  shell: >
+    {{ archivematica_src_ss_virtualenv }}/bin/python -m archivematica.storage_service.manage
+    create_user
+    --username="{{ archivematica_src_configure_ss_user }}"
+    --password="{{ archivematica_src_configure_ss_password }}"
+    --email="{{ archivematica_src_configure_ss_email }}"
+    --api-key="{{ archivematica_src_configure_ss_api_key }}"
+    --superuser
+  args:
+    executable: /bin/bash
   environment: "{{ archivematica_src_ss_environment }}"
   when: archivematica_src_configure_ss|bool and ss_user.stdout == ""
 
@@ -112,22 +112,22 @@
   when: archivematica_src_configure_am_api_key is undefined
 
 - name: "Create Dashboard user and register pipeline on SS"
-  django_manage:
-    command: >
-      install 
-      --username="{{ archivematica_src_configure_am_user }}"
-      --password="{{ archivematica_src_configure_am_password }}"
-      --email="{{ archivematica_src_configure_am_email }}"
-      --site-url="{{ archivematica_src_configure_am_site_url }}"
-      --org-name="{{ archivematica_src_configure_am_org_name }}"
-      --org-id="{{ archivematica_src_configure_am_org_id }}"
-      --api-key="{{ archivematica_src_configure_am_api_key }}"
-      --ss-url="{{ archivematica_src_configure_ss_url }}"
-      --ss-user="{{ archivematica_src_configure_ss_user }}"
-      --ss-api-key="{{ archivematica_src_configure_ss_api_key }}"
-      --whitelist="{{archivematica_src_configure_am_whitelist}}"
-    app_path: "{{ archivematica_src_am_dashboard_app }}"
-    virtualenv: "{{ archivematica_src_am_dashboard_virtualenv }}"
+  shell: >
+    {{ archivematica_src_am_dashboard_virtualenv }}/bin/python -m archivematica.dashboard.manage
+    install
+    --username="{{ archivematica_src_configure_am_user }}"
+    --password="{{ archivematica_src_configure_am_password }}"
+    --email="{{ archivematica_src_configure_am_email }}"
+    --site-url="{{ archivematica_src_configure_am_site_url }}"
+    --org-name="{{ archivematica_src_configure_am_org_name }}"
+    --org-id="{{ archivematica_src_configure_am_org_id }}"
+    --api-key="{{ archivematica_src_configure_am_api_key }}"
+    --ss-url="{{ archivematica_src_configure_ss_url }}"
+    --ss-user="{{ archivematica_src_configure_ss_user }}"
+    --ss-api-key="{{ archivematica_src_configure_ss_api_key }}"
+    --whitelist="{{archivematica_src_configure_am_whitelist}}"
+  args:
+    executable: /bin/bash
   environment: "{{ archivematica_src_am_dashboard_environment }}"
   when: archivematica_src_configure_dashboard|bool and dashboard_user.stdout == "" and dashboard_ss_url.stdout == ""
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -113,7 +113,7 @@
 
 - name: "Create Dashboard user and register pipeline on SS"
   shell: >
-    {{ archivematica_src_am_dashboard_virtualenv }}/bin/python -m archivematica.dashboard.manage
+    {{ archivematica_src_am_virtualenv }}/bin/python -m archivematica.dashboard.manage
     install
     --username="{{ archivematica_src_configure_am_user }}"
     --password="{{ archivematica_src_configure_am_password }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -20,9 +20,8 @@
 
 - name: "Check for SS user"
   become: "yes"
-  shell: echo 'select username from auth_user where username="{{ archivematica_src_configure_ss_user }}";'  | {{ archivematica_src_ss_virtualenv }}/bin/python manage.py dbshell | tail -n1
+  shell: echo 'select username from auth_user where username="{{ archivematica_src_configure_ss_user }}";'  | {{ archivematica_src_ss_virtualenv }}/bin/python -m archivematica.storage_service.manage dbshell | tail -n1
   args:
-    chdir: "{{ archivematica_src_ss_app }}"
     executable: /bin/bash
   environment: "{{ archivematica_src_ss_environment }}"
   register: ss_user
@@ -35,9 +34,8 @@
 - name: "Get SS API Key"
   shell: >
     echo "select \`key\` from tastypie_apikey where id in (select id from auth_user where username = '{{ archivematica_src_configure_ss_user }}');"
-    | {{ archivematica_src_ss_virtualenv }}/bin/python manage.py dbshell | tail -n1
+    | {{ archivematica_src_ss_virtualenv }}/bin/python -m archivematica.storage_service.manage dbshell | tail -n1
   args:
-    chdir: "{{ archivematica_src_ss_app }}"
     executable: /bin/bash
   environment: "{{ archivematica_src_ss_environment }}"
   delegate_to: "{{ archivematica_src_configure_ss_url|urlsplit('hostname') }}"

--- a/tasks/pipeline-dbconf.yml
+++ b/tasks/pipeline-dbconf.yml
@@ -31,7 +31,7 @@
 
 - name: "Run migrations"
   shell: >
-    {{ archivematica_src_am_dashboard_virtualenv }}/bin/python -m archivematica.dashboard.manage
+    {{ archivematica_src_am_virtualenv }}/bin/python -m archivematica.dashboard.manage
     migrate
   args:
     executable: /bin/bash

--- a/tasks/pipeline-dbconf.yml
+++ b/tasks/pipeline-dbconf.yml
@@ -30,9 +30,10 @@
 ###########################################################
 
 - name: "Run migrations"
-  django_manage:
-    command: "migrate"
-    app_path: "{{ archivematica_src_am_dashboard_app }}"
-    virtualenv: "{{ archivematica_src_am_dashboard_virtualenv }}"
+  shell: >
+    {{ archivematica_src_am_dashboard_virtualenv }}/bin/python -m archivematica.dashboard.manage
+    migrate
+  args:
+    executable: /bin/bash
   environment: "{{ archivematica_src_am_dashboard_environment }}"
   tags: "amsrc-pipeline-dbconf-syncdb"

--- a/tasks/pipeline-environment.yml
+++ b/tasks/pipeline-environment.yml
@@ -6,10 +6,6 @@
 #  - services
 #
 
-- name: "set_fact: set gunicorn path to correct value"
-  set_fact:
-    dashboard_gunicorn_path: "{{ archivematica_src_am_dashboard_virtualenv }}/bin/gunicorn"
-
 - name: "Clear shared directory"
   file:
     dest: "{{ archivematica_src_shareddir }}"

--- a/tasks/pipeline-es.yml
+++ b/tasks/pipeline-es.yml
@@ -8,10 +8,11 @@
 
 - block:
   - name: "pipeline-es | Migrate elasticsearch indexes from remote server"
-    django_manage:
-      command: "reindex_from_remote_cluster -t 60 -s 1 {{ archivematica_src_am_elasticserch_source }}"
-      app_path: "{{ archivematica_src_am_dashboard_app }}"
-      virtualenv: "{{ archivematica_src_am_dashboard_virtualenv }}"
+    shell: >
+      {{ archivematica_src_am_dashboard_virtualenv }}/bin/python -m archivematica.dashboard.manage
+      reindex_from_remote_cluster -t 60 -s 1 {{ archivematica_src_am_elasticserch_source }}
+    args:
+      executable: /bin/bash
     environment: "{{ archivematica_src_am_dashboard_environment }}"
 
   - name: "pipeline-es | Verify aip reindex from remote server (system)"

--- a/tasks/pipeline-es.yml
+++ b/tasks/pipeline-es.yml
@@ -9,7 +9,7 @@
 - block:
   - name: "pipeline-es | Migrate elasticsearch indexes from remote server"
     shell: >
-      {{ archivematica_src_am_dashboard_virtualenv }}/bin/python -m archivematica.dashboard.manage
+      {{ archivematica_src_am_virtualenv }}/bin/python -m archivematica.dashboard.manage
       reindex_from_remote_cluster -t 60 -s 1 {{ archivematica_src_am_elasticserch_source }}
     args:
       executable: /bin/bash

--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -68,10 +68,11 @@
 #
 
 - name: "Collect static files"
-  django_manage:
-    command: "collectstatic"
-    app_path: "{{ archivematica_src_am_dashboard_app }}"
-    virtualenv: "{{ archivematica_src_am_dashboard_virtualenv }}"
+  shell: >
+    {{ archivematica_src_am_dashboard_virtualenv }}/bin/python -m archivematica.dashboard.manage
+    collectstatic
+  args:
+    executable: /bin/bash
   environment: "{{ archivematica_src_am_dashboard_environment }}"
 
 #
@@ -79,8 +80,9 @@
 #
 
 - name: "Compile gettext po files (compilemessages)"
-  django_manage:
-    command: "compilemessages"
-    app_path: "{{ archivematica_src_am_dashboard_app }}"
-    virtualenv: "{{ archivematica_src_am_dashboard_virtualenv }}"
+  shell: >
+    {{ archivematica_src_am_dashboard_environment }}/bin/python -m archivematica.dashboard.manage
+    compilemessages
+  args:
+    executable: /bin/bash
   environment: "{{ archivematica_src_am_dashboard_environment }}"

--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -69,8 +69,8 @@
 
 - name: "Collect static files"
   shell: >
-    {{ archivematica_src_am_dashboard_virtualenv }}/bin/python -m archivematica.dashboard.manage
-    collectstatic
+    {{ archivematica_src_am_virtualenv }}/bin/python -m archivematica.dashboard.manage
+    collectstatic --noinput
   args:
     executable: /bin/bash
   environment: "{{ archivematica_src_am_dashboard_environment }}"
@@ -81,7 +81,7 @@
 
 - name: "Compile gettext po files (compilemessages)"
   shell: >
-    {{ archivematica_src_am_dashboard_environment }}/bin/python -m archivematica.dashboard.manage
+    {{ archivematica_src_am_virtualenv }}/bin/python -m archivematica.dashboard.manage
     compilemessages
   args:
     executable: /bin/bash

--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -4,29 +4,22 @@
 #   4- Code install
 ###########################################################
 
-- name: "Symlink source files"
+- name: "Change archivematica-source owner to archivematica"
   file:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    state: "link"
-  with_items:
+    dest: "{{ archivematica_src_dir }}"
+    state: "directory"
+    owner: "archivematica"
+    group: "archivematica"
+    recurse: "yes"
 
-    # archivematicaCommon
-    - src: "{{ archivematica_src_dir }}/archivematica/src/archivematica/archivematicaCommon"
-      dest: "{{ archivematica_src_am_common_app }}"
-
-    # Dashboard
-    - src: "{{ archivematica_src_dir }}/archivematica/src/archivematica/dashboard"
-      dest: "{{ archivematica_src_am_dashboard_app }}"
-
-    # MCPServer
-    - src: "{{ archivematica_src_dir }}/archivematica/src/archivematica/MCPServer"
-      dest: "{{ archivematica_src_am_mcpserver_app }}"
-
-    # MCPClient
-    - src: "{{ archivematica_src_dir }}/archivematica/src/archivematica/MCPClient/"
-      dest: "{{ archivematica_src_am_mcpclient_app }}"
-
+- name: "Install archivematica Python package"
+  become: "yes"
+  become_user: "archivematica"
+  pip:
+    virtualenv: "{{ archivematica_src_am_virtualenv }}"
+    chdir: "{{ archivematica_src_dir }}/archivematica"
+    name: .
+    editable: yes
 
 - name: "Copy gunicorn configuration file"
   copy:
@@ -39,17 +32,6 @@
 #
 # front-end
 #
-
-- name: "Change archivematica-source owner to archivematica"
-  file:
-    dest: "{{ archivematica_src_dir }}"
-    state: "directory"
-    owner: "archivematica"
-    group: "archivematica"
-    recurse: "yes"
-  with_items:
-    - "{{ archivematica_src_dir }}/archivematica/src/archivematica/dashboard/media"
-    - "{{ archivematica_src_dir }}/archivematica/src/archivematica/dashboard/frontend"
 
 - name: "Install front-end dependencies"
   become: "yes"

--- a/tasks/pipeline-osconf.yml
+++ b/tasks/pipeline-osconf.yml
@@ -10,7 +10,6 @@
     state: "directory"
   with_items:
     - "/usr/lib/archivematica"
-    - "/usr/share/archivematica/archivematicaCommon"
     - "/usr/share/archivematica"
     - "/etc/archivematica"
     - "/var/lib/archivematica"

--- a/tasks/ss-db.yml
+++ b/tasks/ss-db.yml
@@ -33,10 +33,11 @@
 
 
 - name: "Run SS django database migrations"
-  django_manage:
-    command: "migrate"
-    app_path: "{{ archivematica_src_ss_app }}"
-    virtualenv: "{{ archivematica_src_ss_virtualenv }}"
+  shell: >
+    {{ archivematica_src_ss_virtualenv }}/bin/python -m archivematica.storage_service.manage
+    migrate
+  args:
+    executable: /bin/bash
   environment: "{{ archivematica_src_ss_environment }}"
 
 - name: "Fix DB permissions"
@@ -48,8 +49,9 @@
   when: "archivematica_src_ss_environment['SS_DB_URL'] is not defined"
 
 - name: "Back create API keys for old users"
-  django_manage:
-    command: "backfill_api_keys"
-    app_path: "{{ archivematica_src_ss_app }}"
-    virtualenv: "{{ archivematica_src_ss_virtualenv }}"
+  shell: >
+    {{ archivematica_src_ss_virtualenv }}/bin/python -m archivematica.storage_service.manage
+    backfill_api_keys
+  args:
+    executable: /bin/bash
   environment: "{{ archivematica_src_ss_environment }}"

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -195,18 +195,20 @@
   tags: "amsrc-ss-code"
 
 - name: "Run SS django collectstatic"
-  django_manage:
-    command: "collectstatic"
-    app_path: "{{ archivematica_src_ss_app }}"
-    virtualenv: "{{ archivematica_src_ss_virtualenv }}"
+  shell: >
+    {{ archivematica_src_ss_virtualenv }}/bin/python -m archivematica.storage_service.manage
+    collectstatic
+  args:
+    executable: /bin/bash
   environment: "{{ archivematica_src_ss_environment }}"
   tags: ["amsrc-ss-code", "amsrc-ss-code-collectstatic"]
 
 - name: "Run SS django compilemessages"
-  django_manage:
-    command: "compilemessages"
-    app_path: "{{ archivematica_src_ss_app }}"
-    virtualenv: "{{ archivematica_src_ss_virtualenv }}"
+  shell: >
+    {{ archivematica_src_ss_virtualenv }}/bin/python -m archivematica.storage_service.manage
+    compilemessages
+  args:
+    executable: /bin/bash
   environment: "{{ archivematica_src_ss_environment }}"
   tags: ["amsrc-ss-code", "amsrc-ss-code-compilemessages"]
 

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -179,7 +179,7 @@
 - name: "Run SS django collectstatic"
   shell: >
     {{ archivematica_src_ss_virtualenv }}/bin/python -m archivematica.storage_service.manage
-    collectstatic
+    collectstatic --noinput
   args:
     executable: /bin/bash
   environment: "{{ archivematica_src_ss_environment }}"

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -132,14 +132,6 @@
 #   3- OS configuration (user/directory/file creation/permissions/ownership)
 ###########################################################
 
-- name: "Create subdirectory for archivematica-storage-service source files"
-  file:
-    dest: "{{ item }}"
-    state: "directory"
-  with_items:
-    - "/usr/lib/archivematica"
-  tags: "amsrc-ss-osconf"
-
 - name: "Create subdirectory for archivematica-storage-service database file"
   file:
     dest: "{{ item }}"
@@ -183,16 +175,6 @@
 ###########################################################
 #   4- SS code install
 ###########################################################
-
-- name: "Copy archivematica-storage-service source files"
-  file:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    state: "link"
-  with_items:
-    - src: "{{ archivematica_src_dir }}/archivematica-storage-service/src/archivematica/storage_service"
-      dest: "{{ archivematica_src_ss_app }}"
-  tags: "amsrc-ss-code"
 
 - name: "Run SS django collectstatic"
   shell: >

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -111,6 +111,23 @@
     LANG: "en_US.utf8"
   tags: "amsrc-ss-pydep"
 
+- name: "Change archivematica source owner to archivematica"
+  file:
+    dest: "{{ archivematica_src_dir }}"
+    state: "directory"
+    owner: "archivematica"
+    group: "archivematica"
+    recurse: "yes"
+
+- name: "Install archivematica-storage-service Python package"
+  become: "yes"
+  become_user: "archivematica"
+  pip:
+    virtualenv: "{{ archivematica_src_ss_virtualenv }}"
+    chdir: "{{ archivematica_src_dir }}/archivematica-storage-service"
+    name: .
+    editable: yes
+
 ###########################################################
 #   3- OS configuration (user/directory/file creation/permissions/ownership)
 ###########################################################

--- a/tasks/ss-migrate-sqlite3.yml
+++ b/tasks/ss-migrate-sqlite3.yml
@@ -41,27 +41,28 @@
 - name: "Run SS django database migrations in sqlite3 database"
   become: "yes"
   become_user: "archivematica"
-  django_manage:
-    command: "migrate"
-    app_path: "{{ archivematica_src_ss_app }}"
-    virtualenv: "{{ archivematica_src_ss_virtualenv }}"
+  shell: >
+    {{ archivematica_src_ss_virtualenv }}/bin/python -m archivematica.storage_service.manage
+    migrate
+  args:
+    executable: /bin/bash
   environment: "{{ __archivematica_src_ss_environment_remove_SS_DB_URL }}"
 
 - name: "Create a dump from django SS database (sqlite3)"
   become: "yes"
   become_user: "archivematica"
-  django_manage:
-    command: >
-      dumpdata
-      --exclude auth.permission
-      --exclude contenttypes
-      --exclude sessions.session
-      --natural-foreign
-      --natural-primary
-      --indent 4
-      --output /tmp/datadump_{{ date_result.stdout }}.json
-    app_path: "{{ archivematica_src_ss_app }}"
-    virtualenv: "{{ archivematica_src_ss_virtualenv }}"
+  shell: >
+    {{ archivematica_src_ss_virtualenv }}/bin/python -m archivematica.storage_service.manage
+    dumpdata
+    --exclude auth.permission
+    --exclude contenttypes
+    --exclude sessions.session
+    --natural-foreign
+    --natural-primary
+    --indent 4
+    --output /tmp/datadump_{{ date_result.stdout }}.json
+  args:
+    executable: /bin/bash
   environment: "{{ __archivematica_src_ss_environment_remove_SS_DB_URL }}"
 
 - name: "Remove SS DB (mysql)"
@@ -81,18 +82,19 @@
 - name: "Run SS django database migrations (To syncdb database)"
   become: "yes"
   become_user: "archivematica"
-  django_manage:
-    command: "migrate"
-    app_path: "{{ archivematica_src_ss_app }}"
-    virtualenv: "{{ archivematica_src_ss_virtualenv }}"
+  shell: >
+    {{ archivematica_src_ss_virtualenv }}/bin/python -m archivematica.storage_service.manage
+    migrate
+  args:
+    executable: /bin/bash
   environment: "{{ archivematica_src_ss_environment }}"
 
 - name: "Load database from the sqlite3 dump"
   become: "yes"
   become_user: "archivematica"
-  django_manage:
-    command: "loaddata"
-    fixtures: "/tmp/datadump_{{ date_result.stdout }}.json"
-    app_path: "{{ archivematica_src_ss_app }}"
-    virtualenv: "{{ archivematica_src_ss_virtualenv }}"
+  shell: >
+    {{ archivematica_src_ss_virtualenv }}/bin/python -m archivematica.storage_service.manage
+    loaddata /tmp/datadump_{{ date_result.stdout }}.json
+  args:
+    executable: /bin/bash
   environment: "{{ archivematica_src_ss_environment }}"

--- a/tasks/ss-migrate-sqlite3.yml
+++ b/tasks/ss-migrate-sqlite3.yml
@@ -33,9 +33,8 @@
   become_user: "archivematica"
   shell: >
     echo "delete from locations_event where package_id not in (select f.id from locations_package f);"
-    | {{ archivematica_src_ss_virtualenv }}/bin/python manage.py dbshell
+    | {{ archivematica_src_ss_virtualenv }}/bin/python -m archivematica.storage_service.manage dbshell
   args:
-    chdir: "{{ archivematica_src_ss_app }}"
     executable: /bin/bash
   environment: "{{ __archivematica_src_ss_environment_remove_SS_DB_URL }}"
 

--- a/templates/bin/fixity
+++ b/templates/bin/fixity
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 source {{ systemd_environment_path }}/fixity
-/usr/share/archivematica/virtualenvs/fixity//bin/fixity $*
+/usr/share/archivematica/virtualenvs/fixity/bin/fixity $*

--- a/templates/bin/fixity-cron
+++ b/templates/bin/fixity-cron
@@ -9,10 +9,9 @@ function get_emails(){
                 source /etc/default/archivematica-storage-service || \
                 source /etc/sysconfig/archivematica-storage-service \
                         || (echo 'Environment file not found'; exit 1)
-                cd /usr/lib/archivematica/storage_service
                 echo 'select email from auth_user;' | \
                         /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python \
-                        manage.py dbshell 2> /dev/null | tail -n+2 | grep -v 'x@x'| grep -v ^$ | sort -u
+                        -m archivematica.storage_service.manage dbshell 2> /dev/null | tail -n+2 | grep -v 'x@x'| grep -v ^$ | sort -u
 ";
 }
 

--- a/templates/etc/sysconfig/archivematica-dashboard.j2
+++ b/templates/etc/sysconfig/archivematica-dashboard.j2
@@ -1,6 +1,5 @@
 # {{ ansible_managed }}
 
-PYTHONPATH=/usr/lib:/usr/share
 LANG="en_US.UTF-8"
 LC_ALL="en_US.UTF-8"
 LC_LANG="en_US.UTF-8"

--- a/templates/etc/sysconfig/archivematica-mcp-client.j2
+++ b/templates/etc/sysconfig/archivematica-mcp-client.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-PATH={{ archivematica_src_am_mcpclient_virtualenv }}/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
+PATH={{ archivematica_src_am_virtualenv }}/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
 LANG="en_US.UTF-8"
 LC_ALL="en_US.UTF-8"
 LC_LANG="en_US.UTF-8"

--- a/templates/etc/sysconfig/archivematica-mcp-client.j2
+++ b/templates/etc/sysconfig/archivematica-mcp-client.j2
@@ -1,7 +1,6 @@
 # {{ ansible_managed }}
 
 PATH={{ archivematica_src_am_mcpclient_virtualenv }}/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
-PYTHONPATH=/usr/lib:/usr/share
 LANG="en_US.UTF-8"
 LC_ALL="en_US.UTF-8"
 LC_LANG="en_US.UTF-8"

--- a/templates/etc/sysconfig/archivematica-mcp-server.j2
+++ b/templates/etc/sysconfig/archivematica-mcp-server.j2
@@ -1,6 +1,5 @@
 # {{ ansible_managed }}
 
-PYTHONPATH=/usr/lib:/usr/share
 LANG="en_US.UTF-8"
 LC_ALL="en_US.UTF-8"
 LC_LANG="en_US.UTF-8"

--- a/templates/etc/systemd/system/archivematica-dashboard.service.j2
+++ b/templates/etc/systemd/system/archivematica-dashboard.service.j2
@@ -17,8 +17,7 @@ StandardError=syslog
 SyslogIdentifier=DashboardStdout
 SyslogFacility={{ archivematica_src_syslog_dashboard_facility }}
 {% endif %}
-WorkingDirectory={{ archivematica_src_am_dashboard_app }}
-ExecStart={{ dashboard_gunicorn_path }} --config {{ archivematica_src_am_dashboard_gunicorn_config }} wsgi:application
+ExecStart={{ dashboard_gunicorn_path }} --config {{ archivematica_src_am_dashboard_gunicorn_config }} archivematica.dashboard.wsgi:application
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true

--- a/templates/etc/systemd/system/archivematica-dashboard.service.j2
+++ b/templates/etc/systemd/system/archivematica-dashboard.service.j2
@@ -17,7 +17,7 @@ StandardError=syslog
 SyslogIdentifier=DashboardStdout
 SyslogFacility={{ archivematica_src_syslog_dashboard_facility }}
 {% endif %}
-ExecStart={{ archivematica_src_am_dashboard_virtualenv }}/bin/gunicorn --config {{ archivematica_src_am_dashboard_gunicorn_config }} archivematica.dashboard.wsgi:application
+ExecStart={{ archivematica_src_am_virtualenv }}/bin/gunicorn --config {{ archivematica_src_am_dashboard_gunicorn_config }} archivematica.dashboard.wsgi:application
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true

--- a/templates/etc/systemd/system/archivematica-dashboard.service.j2
+++ b/templates/etc/systemd/system/archivematica-dashboard.service.j2
@@ -17,7 +17,7 @@ StandardError=syslog
 SyslogIdentifier=DashboardStdout
 SyslogFacility={{ archivematica_src_syslog_dashboard_facility }}
 {% endif %}
-ExecStart={{ dashboard_gunicorn_path }} --config {{ archivematica_src_am_dashboard_gunicorn_config }} archivematica.dashboard.wsgi:application
+ExecStart={{ archivematica_src_am_dashboard_virtualenv }}/bin/gunicorn --config {{ archivematica_src_am_dashboard_gunicorn_config }} archivematica.dashboard.wsgi:application
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true

--- a/templates/etc/systemd/system/archivematica-mcp-client.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-client.service.j2
@@ -21,7 +21,7 @@ StandardError=syslog
 SyslogIdentifier=MCPClientStdout
 SyslogFacility={{ archivematica_src_syslog_mcpclient_facility }}
 {% endif %}
-ExecStart={{ archivematica_src_am_mcpclient_virtualenv }}/bin/python {{ archivematica_src_am_mcpclient_app }}/archivematicaClient.py
+ExecStart={{ archivematica_src_am_mcpclient_virtualenv }}/bin/python -m archivematica.MCPClient.archivematicaClient
 Restart=always
 RestartSec=30
 

--- a/templates/etc/systemd/system/archivematica-mcp-client.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-client.service.j2
@@ -21,7 +21,7 @@ StandardError=syslog
 SyslogIdentifier=MCPClientStdout
 SyslogFacility={{ archivematica_src_syslog_mcpclient_facility }}
 {% endif %}
-ExecStart={{ archivematica_src_am_mcpclient_virtualenv }}/bin/python -m archivematica.MCPClient.archivematicaClient
+ExecStart={{ archivematica_src_am_virtualenv }}/bin/python -m archivematica.MCPClient.archivematicaClient
 Restart=always
 RestartSec=30
 

--- a/templates/etc/systemd/system/archivematica-mcp-server.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-server.service.j2
@@ -15,7 +15,7 @@ StandardError=syslog
 SyslogIdentifier=MCPServerStdout
 SyslogFacility={{ archivematica_src_syslog_mcpserver_facility }}
 {% endif %}
-ExecStart={{ archivematica_src_am_mcpserver_virtualenv }}/bin/python {{ archivematica_src_am_mcpserver_app }}/archivematicaMCP.py
+ExecStart={{ archivematica_src_am_mcpserver_virtualenv }}/bin/python -m archivematica.MCPServer.archivematicaMCP
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/etc/systemd/system/archivematica-mcp-server.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-server.service.j2
@@ -15,7 +15,7 @@ StandardError=syslog
 SyslogIdentifier=MCPServerStdout
 SyslogFacility={{ archivematica_src_syslog_mcpserver_facility }}
 {% endif %}
-ExecStart={{ archivematica_src_am_mcpserver_virtualenv }}/bin/python -m archivematica.MCPServer.archivematicaMCP
+ExecStart={{ archivematica_src_am_virtualenv }}/bin/python -m archivematica.MCPServer.archivematicaMCP
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/etc/systemd/system/archivematica-storage-service.service.j2
+++ b/templates/etc/systemd/system/archivematica-storage-service.service.j2
@@ -16,8 +16,7 @@ SyslogIdentifier=StorageStdout
 SyslogFacility={{ archivematica_src_syslog_storageservice_facility }}
 {% endif %}
 
-WorkingDirectory={{ archivematica_src_ss_app }}
-ExecStart={{ archivematica_src_ss_virtualenv }}/bin/gunicorn --config {{ archivematica_src_ss_gunicorn_config }} storage_service.wsgi:application
+ExecStart={{ archivematica_src_ss_virtualenv }}/bin/gunicorn --config {{ archivematica_src_ss_gunicorn_config }} archivematica.storage_service.storage_service.wsgi:application
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true

--- a/vars/envs.yml
+++ b/vars/envs.yml
@@ -6,7 +6,6 @@
 _archivematica_src_am_dashboard_environment:
   DJANGO_SETTINGS_MODULE: "archivematica.dashboard.settings.production"
   ARCHIVEMATICA_DASHBOARD_DASHBOARD_DJANGO_ALLOWED_HOSTS: "*"
-  PYTHONPATH: "/usr/lib:/usr/share"
 
 
   ARCHIVEMATICA_DASHBOARD_DASHBOARD_DJANGO_SECRET_KEY: '{{ archivematica_src_am_django_secret_key | default("CHANGE_ME_WITH_A_SECRET_KEY") }}'
@@ -44,5 +43,3 @@ _archivematica_src_ss_environment:
   EMAIL_HOST_USER: ""
   EMAIL_PORT: "25"
   SS_AUDIT_LOG_MIDDLEWARE: "{{ archivematica_src_audit|default('false') }}"
-  SS_GUNICORN_CHDIR: "/usr/lib/"
-  PYTHONPATH: "/usr/lib:/usr/share"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,20 +4,13 @@ ansible_deps: []
 archivematica_src_am_virtualenv: "/usr/share/archivematica/virtualenvs/archivematica"
 
 archivematica_src_am_dashboard_virtualenv: "{{ archivematica_src_am_virtualenv }}"
-archivematica_src_am_dashboard_app: "/usr/share/archivematica/dashboard"
 archivematica_src_am_dashboard_gunicorn_config: "/etc/archivematica/dashboard.gunicorn-config.py"
 
 archivematica_src_am_mcpserver_virtualenv: "{{ archivematica_src_am_virtualenv }}"
-archivematica_src_am_mcpserver_app: "/usr/lib/archivematica/MCPServer"
 
 archivematica_src_am_mcpclient_virtualenv: "{{ archivematica_src_am_virtualenv }}"
-archivematica_src_am_mcpclient_app: "/usr/lib/archivematica/MCPClient"
-archivematica_src_am_mcpclient_modules_app: "/usr/lib/archivematica/MCPClient/clientScripts"
-
-archivematica_src_am_common_app: "/usr/lib/archivematica/archivematicaCommon"
 
 archivematica_src_ss_virtualenv: "/usr/share/archivematica/virtualenvs/archivematica-storage-service"
-archivematica_src_ss_app: "/usr/lib/archivematica/storage_service"
 archivematica_src_ss_gunicorn_config: "/etc/archivematica/storage-service.gunicorn-config.py"
 
 archivematica_src_am_amauat_deps: []

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,13 +2,7 @@
 ansible_deps: []
 
 archivematica_src_am_virtualenv: "/usr/share/archivematica/virtualenvs/archivematica"
-
-archivematica_src_am_dashboard_virtualenv: "{{ archivematica_src_am_virtualenv }}"
 archivematica_src_am_dashboard_gunicorn_config: "/etc/archivematica/dashboard.gunicorn-config.py"
-
-archivematica_src_am_mcpserver_virtualenv: "{{ archivematica_src_am_virtualenv }}"
-
-archivematica_src_am_mcpclient_virtualenv: "{{ archivematica_src_am_virtualenv }}"
 
 archivematica_src_ss_virtualenv: "/usr/share/archivematica/virtualenvs/archivematica-storage-service"
 archivematica_src_ss_gunicorn_config: "/etc/archivematica/storage-service.gunicorn-config.py"


### PR DESCRIPTION
This installs the AM and SS source directories as [editable Python packages](https://setuptools.pypa.io/en/latest/userguide/development_mode.html) and simplifies paths and virtual environments management in the role.

For code review, I recommend going through each individual commit and reading the accompanying commit messages, which provide context and explain the reasons behind some of the changes.

Connected to https://github.com/archivematica/Issues/issues/1733
Connected to https://github.com/archivematica/Issues/issues/1749