### PR TITLE
Add --no-deps flag to pip installs for AM components

### DIFF
--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -20,6 +20,7 @@
     chdir: "{{ archivematica_src_dir }}/archivematica"
     name: .
     editable: yes
+    extra_args: "--no-deps"
 
 - name: "Copy gunicorn configuration file"
   copy:

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -128,6 +128,7 @@
     chdir: "{{ archivematica_src_dir }}/archivematica-storage-service"
     name: .
     editable: yes
+    extra_args: "--no-deps"
 
 ###########################################################
 #   3- OS configuration (user/directory/file creation/permissions/ownership)


### PR DESCRIPTION
Skip dependency resolution when installing Archivematica and Storage Service in editable mode since requirements are already synchronized via pip-sync in previous tasks. This prevents conflicts between pinned dependencies and those listed in `pyproject.toml`.

Connected to https://github.com/archivematica/Issues/issues/1733