### PR TITLE
Add support for GnuPG v2

### DIFF
--- a/tasks/configure-gpg.yml
+++ b/tasks/configure-gpg.yml
@@ -63,14 +63,20 @@
                   gnupghome = '{{ archivematica_src_configure_gpg.gpg_home_directory }}',
                   gpgbinary = '{{ gpg_binary }}'
                 )
-          input_data = gpg.gen_key_input(
-            name_email = '{{ archivematica_src_configure_gpg.key_mail }}',
+          passphrase = '{{ archivematica_src_configure_gpg.key_passphrase }}'
+          key_input_kwargs = dict(
+            name_email = '{{ archivematica_src_configure_gpg.key_mail }}',
             name_comment = '{{ archivematica_src_configure_gpg.key_comment }}',
             name_real = '{{ archivematica_src_configure_gpg.key_user }}',
-            passphrase = '{{ archivematica_src_configure_gpg.key_passphrase }}',
             key_length = '4096',
             key_type = 'RSA'
           )
+          if passphrase:
+            key_input_kwargs['passphrase'] = passphrase
+          else:
+            # GnuPG >= 2.1 requires explicit %no-protection for unpassphrased keys.
+            key_input_kwargs['no_protection'] = True
+          input_data = gpg.gen_key_input(**key_input_kwargs)
           key = gpg.gen_key(input_data)
           print(key)
       register: "gpg_fingerprint"

--- a/tasks/configure-gpg.yml
+++ b/tasks/configure-gpg.yml
@@ -15,15 +15,25 @@
 - name: "Add GPG space and locations"
   block:
 
-    - name: "Set gpg binary name (Bionic)"
-      set_fact:
-        gpg_binary: "gpg1"
-      when: "ansible_distribution_version is version('18.04', '>=')"
+    - name: "Detect gpg binary"
+      shell: |
+        set -e
+        for candidate in gpg gpg2 gpg1; do
+          if command -v "$candidate" >/dev/null 2>&1; then
+            command -v "$candidate"
+            exit 0
+          fi
+        done
+        exit 1
+      args:
+        executable: "/bin/bash"
+      register: "gpg_binary_path"
+      changed_when: false
+      check_mode: false
 
-    - name: "Set gpg binary name (Distribution!=Bionic)"
+    - name: "Set gpg binary path"
       set_fact:
-        gpg_binary: "gpg"
-      when: "ansible_distribution_version is version('18.04', '<')"
+        gpg_binary: "{{ gpg_binary_path.stdout | trim }}"
 
     - name: "Check whether GPG already exists"
       shell: >
@@ -51,7 +61,7 @@
 
           gpg = gnupg.GPG(
                   gnupghome = '{{ archivematica_src_configure_gpg.gpg_home_directory }}',
-                  gpgbinary = '{{ gpg_binary }}'
+                  gpgbinary = '{{ gpg_binary }}'
                 )
           input_data = gpg.gen_key_input(
             name_email = '{{ archivematica_src_configure_gpg.key_mail }}',

--- a/vars/AlmaLinux-9.yml
+++ b/vars/AlmaLinux-9.yml
@@ -106,7 +106,7 @@ storage_service_osdeps:
     - gettext
     - p7zip
     - p7zip-plugins
-    - gnupg1
+    - gnupg2
     - rng-tools
     - openldap-devel
     - rclone

--- a/vars/OracleLinux-9.yml
+++ b/vars/OracleLinux-9.yml
@@ -106,7 +106,7 @@ storage_service_osdeps:
     - gettext
     - p7zip
     - p7zip-plugins
-    - gnupg1
+    - gnupg2
     - rng-tools
     - openldap-devel
     - rclone

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -110,7 +110,7 @@ storage_service_osdeps:
     - gettext
     - p7zip
     - p7zip-plugins
-    - gnupg1
+    - gnupg2
     - rng-tools
     - openldap-devel
     - rclone

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -106,7 +106,7 @@ storage_service_osdeps:
     - gettext
     - p7zip
     - p7zip-plugins
-    - gnupg1
+    - gnupg2
     - rng-tools
     - openldap-devel
     - rclone

--- a/vars/Rocky-8.yml
+++ b/vars/Rocky-8.yml
@@ -110,7 +110,7 @@ storage_service_osdeps:
     - gettext
     - p7zip
     - p7zip-plugins
-    - gnupg1
+    - gnupg2
     - rng-tools
     - openldap-devel
     - rclone

--- a/vars/Rocky-9.yml
+++ b/vars/Rocky-9.yml
@@ -106,7 +106,7 @@ storage_service_osdeps:
     - gettext
     - p7zip
     - p7zip-plugins
-    - gnupg1
+    - gnupg2
     - rng-tools
     - openldap-devel
     - rclone

--- a/vars/Ubuntu-22.yml
+++ b/vars/Ubuntu-22.yml
@@ -103,7 +103,7 @@ storage_service_osdeps:
     - libssl-dev
     - gcc   # required to build some pip dependencies
     - gettext
-    - gnupg1
+    - gnupg2
     - rng-tools-debian
     - libsasl2-dev
     - libldap2-dev

--- a/vars/Ubuntu-24.yml
+++ b/vars/Ubuntu-24.yml
@@ -103,7 +103,7 @@ storage_service_osdeps:
     - libssl-dev
     - gcc   # required to build some pip dependencies
     - gettext
-    - gnupg1
+    - gnupg2
     - rng-tools-debian
     - libsasl2-dev
     - libldap2-dev


### PR DESCRIPTION
This updates GPG binary detection and key generation to support GnuPG
v2, and bumps the package version in the vars files.

Connected to https://github.com/archivematica/Issues/issues/1781
Depends on https://github.com/artefactual/archivematica-storage-service/pull/853