### PR TITLE
Use Rocky extras repositories for SS setup

### DIFF
--- a/vars/AlmaLinux-9.yml
+++ b/vars/AlmaLinux-9.yml
@@ -88,8 +88,14 @@ MCPServer_osdeps:
   packages: []
 
 storage_service_osdeps:
-  repokeys: []
-  repos: []
+  repokeys:
+    - "https://packages.archivematica.org/GPG-KEY-archivematica-sha512"
+  repos:
+    - baseurl: "https://packages.archivematica.org/1.18.x/rocky9-extras"
+      description: "archivematica extras"
+      enabled: "yes"
+      gpgcheck: "no"
+      name: "archivematica-extras"
   packages:
     - epel-release  # required by unar and nginx
   packages_2:

--- a/vars/OracleLinux-9.yml
+++ b/vars/OracleLinux-9.yml
@@ -88,8 +88,14 @@ MCPServer_osdeps:
   packages: []
 
 storage_service_osdeps:
-  repokeys: []
-  repos: []
+  repokeys:
+    - "https://packages.archivematica.org/GPG-KEY-archivematica-sha512"
+  repos:
+    - baseurl: "https://packages.archivematica.org/1.18.x/rocky9-extras"
+      description: "archivematica extras"
+      enabled: "yes"
+      gpgcheck: "no"
+      name: "archivematica-extras"
   packages:
     - epel-release  # required by unar and nginx
   packages_2:

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -92,8 +92,14 @@ MCPServer_osdeps:
   packages: []
 
 storage_service_osdeps:
-  repokeys: []
-  repos: []
+  repokeys:
+    - "https://packages.archivematica.org/GPG-KEY-archivematica-sha512"
+  repos:
+    - baseurl: "https://packages.archivematica.org/1.18.x/rocky8-extras"
+      description: "archivematica extras"
+      enabled: "yes"
+      gpgcheck: "no"
+      name: "archivematica-extras"
   packages:
     - epel-release  # required by unar and nginx
   packages_2:

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -88,8 +88,14 @@ MCPServer_osdeps:
   packages: []
 
 storage_service_osdeps:
-  repokeys: []
-  repos: []
+  repokeys:
+    - "https://packages.archivematica.org/GPG-KEY-archivematica-sha512"
+  repos:
+    - baseurl: "https://packages.archivematica.org/1.18.x/rocky9-extras"
+      description: "archivematica extras"
+      enabled: "yes"
+      gpgcheck: "no"
+      name: "archivematica-extras"
   packages:
     - epel-release  # required by unar and nginx
   packages_2:

--- a/vars/Rocky-8.yml
+++ b/vars/Rocky-8.yml
@@ -92,8 +92,14 @@ MCPServer_osdeps:
   packages: []
 
 storage_service_osdeps:
-  repokeys: []
-  repos: []
+  repokeys:
+    - "https://packages.archivematica.org/GPG-KEY-archivematica-sha512"
+  repos:
+    - baseurl: "https://packages.archivematica.org/1.18.x/rocky8-extras"
+      description: "archivematica extras"
+      enabled: "yes"
+      gpgcheck: "no"
+      name: "archivematica-extras"
   packages:
     - epel-release  # required by unar and nginx
   packages_2:

--- a/vars/Rocky-9.yml
+++ b/vars/Rocky-9.yml
@@ -88,8 +88,14 @@ MCPServer_osdeps:
   packages: []
 
 storage_service_osdeps:
-  repokeys: []
-  repos: []
+  repokeys:
+    - "https://packages.archivematica.org/GPG-KEY-archivematica-sha512"
+  repos:
+    - baseurl: "https://packages.archivematica.org/1.18.x/rocky9-extras"
+      description: "archivematica extras"
+      enabled: "yes"
+      gpgcheck: "no"
+      name: "archivematica-extras"
   packages:
     - epel-release  # required by unar and nginx
   packages_2:


### PR DESCRIPTION
We now serve gnupg1 from the Rocky 8/9 extras repositories, so this adds the repo URL and key to the RHEL-based vars files.

Connected to https://github.com/archivematica/Issues/issues/1781