### PR TITLE
Remove get-pip bootstrap in favor of Python venv

### DIFF
--- a/tasks/acceptance-tests.yml
+++ b/tasks/acceptance-tests.yml
@@ -45,7 +45,6 @@
     requirements: "requirements.txt"
     virtualenv: "/usr/share/archivematica/virtualenvs/archivematica-acceptance-tests"
     virtualenv_command: "{{ archivematica_src_virtualenv }}"
-    virtualenv_python: "{{ archivematica_src_virtualenv_python }}"
     state: latest
 
 #

--- a/tasks/automation-tools.yml
+++ b/tasks/automation-tools.yml
@@ -36,7 +36,6 @@
     requirements: "requirements.txt"
     virtualenv: "/usr/share/archivematica/virtualenvs/automation-tools"
     virtualenv_command: "{{ archivematica_src_virtualenv }}"
-    virtualenv_python: "{{ archivematica_src_virtualenv_python }}"
     state: latest
 
 - name: "symlink automation-tools source to /usr/lib/archivematica"

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -17,7 +17,7 @@
     home: "/var/lib/archivematica"
 
 #
-# Prepare pip
+# Prepare Python environment
 #
 
 - name: "Common configuration for source installs"
@@ -58,30 +58,6 @@
     when:
       - ansible_os_family in ['Rocky','RedHat']
       - ansible_distribution_major_version|int >= 8
-
-  - name: "Download get-pip.py in archivematica userdir"
-    get_url:
-      url: "https://bootstrap.pypa.io/get-pip.py"
-      force: "yes"
-      dest: "/var/lib/archivematica/get-pip.py"
-      owner: "archivematica"
-      group: "archivematica"
-
-  - name: "Install pip with get-pip.py as archivematica user"
-    become: "yes"
-    become_user: "archivematica"
-    command: "{{ archivematica_src_virtualenv_python }} get-pip.py pip=={{ archivematica_src_pip_version }}"
-    args:
-      chdir: "/var/lib/archivematica"
-
-  - name: "Install virtualenv with pip"
-    become: "yes"
-    become_user: "archivematica"
-    pip:
-      name: "virtualenv"
-      executable: "{{ archivematica_src_pip }}"
-      extra_args: "--user --ignore-installed"
-      state: "latest"
 
   #
   # Prepare `archivematica_src_dir`

--- a/tasks/fixity.yml
+++ b/tasks/fixity.yml
@@ -35,7 +35,6 @@
     requirements: "requirements.txt"
     virtualenv: "{{ archivematica_src_fixity_virtualenv }}"
     virtualenv_command: "{{ archivematica_src_virtualenv }}"
-    virtualenv_python: "{{ archivematica_src_virtualenv_python }}"
     state: "latest"
 
 - name: "Install fixity using pip"
@@ -46,7 +45,6 @@
     chdir: "{{ archivematica_src_dir }}/fixity"
     virtualenv: "{{ archivematica_src_fixity_virtualenv }}"
     virtualenv_command: "{{ archivematica_src_virtualenv }}"
-    virtualenv_python: "{{ archivematica_src_virtualenv_python }}"
     state: "latest"
 
 - name: "Change virtualenv owner to archivematica"

--- a/tasks/pipeline-pip-deps.yml
+++ b/tasks/pipeline-pip-deps.yml
@@ -30,7 +30,6 @@
   pip:
     virtualenv: "{{ archivematica_src_am_virtualenv }}"
     virtualenv_command: "{{ archivematica_src_virtualenv }}"
-    virtualenv_python: "{{ archivematica_src_virtualenv_python }}"
     name: 
       - "pip=={{ archivematica_src_pip_version }}"
       - "pip-tools=={{ archivematica_src_pip_tools_version }}"

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -95,7 +95,6 @@
   pip:
     virtualenv: "{{ archivematica_src_ss_virtualenv }}"
     virtualenv_command: "{{ archivematica_src_virtualenv }}"
-    virtualenv_python: "{{ archivematica_src_virtualenv_python }}"
     name: 
       - "pip=={{ archivematica_src_pip_version }}"
       - "pip-tools=={{ archivematica_src_pip_tools_version }}"

--- a/vars/AlmaLinux-9.yml
+++ b/vars/AlmaLinux-9.yml
@@ -18,6 +18,7 @@ archivematica_src_am_fixity_deps:
   - "moreutils"
   - "s-nail"                  # Replaces mailx
 archivematica_src_python_packages:
+  - "python3.12"
   - "python3.12-devel"
   - "python3.12-setuptools"
   - "pkgconfig"

--- a/vars/OracleLinux-9.yml
+++ b/vars/OracleLinux-9.yml
@@ -18,6 +18,7 @@ archivematica_src_am_fixity_deps:
   - "moreutils"
   - "s-nail"                  # Replaces mailx
 archivematica_src_python_packages:
+  - "python3.12"
   - "python3.12-devel"
   - "python3.12-setuptools"
   - "pkgconfig"

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -20,6 +20,7 @@ archivematica_src_am_fixity_deps:
 archivematica_src_python_packages:
   - "python36"        # Required for ansible package module
   - "python3-dnf"     # Required for ansible package module
+  - "python3.12"
   - "python3.12-devel"
   - "python3.12-setuptools"
   - "pkgconfig"

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -18,6 +18,7 @@ archivematica_src_am_fixity_deps:
   - "moreutils"
   - "s-nail"                  # Replaces mailx
 archivematica_src_python_packages:
+  - "python3.12"
   - "python3.12-devel"
   - "python3.12-setuptools"
   - "pkgconfig"

--- a/vars/Rocky-8.yml
+++ b/vars/Rocky-8.yml
@@ -20,6 +20,7 @@ archivematica_src_am_fixity_deps:
 archivematica_src_python_packages:
   - "python36"        # Required for ansible package module
   - "python3-dnf"     # Required for ansible package module
+  - "python3.12"
   - "python3.12-devel"
   - "python3.12-setuptools"
   - "pkgconfig"

--- a/vars/Rocky-9.yml
+++ b/vars/Rocky-9.yml
@@ -18,6 +18,7 @@ archivematica_src_am_fixity_deps:
   - "moreutils"
   - "s-nail"                  # Replaces mailx
 archivematica_src_python_packages:
+  - "python3.12"
   - "python3.12-devel"
   - "python3.12-setuptools"
   - "pkgconfig"

--- a/vars/Ubuntu-22.yml
+++ b/vars/Ubuntu-22.yml
@@ -19,6 +19,7 @@ archivematica_src_am_fixity_deps:
   - "mailutils"
 archivematica_src_python_packages:
   - "python3.12-dev"
+  - "python3.12-venv"
   - "python3-setuptools"
   - "pkg-config"
 

--- a/vars/Ubuntu-24.yml
+++ b/vars/Ubuntu-24.yml
@@ -19,6 +19,7 @@ archivematica_src_am_fixity_deps:
   - "mailutils"
 archivematica_src_python_packages:
   - "python3.12-dev"
+  - "python3.12-venv"
   - "python3-setuptools"
   - "pkg-config"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,8 +10,7 @@ archivematica_src_ss_gunicorn_config: "/etc/archivematica/storage-service.gunico
 archivematica_src_am_amauat_deps: []
 archivematica_src_am_fixity_deps: []
 
-archivematica_src_virtualenv: "/var/lib/archivematica/.local/bin/virtualenv"
-archivematica_src_pip: "/var/lib/archivematica/.local/bin/pip"
+archivematica_src_virtualenv: "{{ archivematica_src_virtualenv_python }} -m venv"
 archivematica_src_virtualenv_python: "python3.12"
 archivematica_src_python_packages: []  # Distro specific (see Debian.yml and RedHat.yml).
 


### PR DESCRIPTION
This change modernizes Python environment setup by replacing get-pip.py bootstrapping with standard virtual environment tooling using distro-provided Python capabilities.

The get-pip.py approach bypasses distro package management, introducing unnecessary variability and reliability issues on newer systems. Using venv aligns with modern Python best practices and reduces maintenance burden.