### PR TITLE
Fix ES reset indexes task

### DIFF
--- a/tasks/pipeline-es.yml
+++ b/tasks/pipeline-es.yml
@@ -51,7 +51,7 @@
 - block:
     - name: "pipeline-es | Reset Elasticsearch indexes"
       uri:
-        url: "http://{{ es_host }}:{{es_port}}/{{ item }}"
+        url: "{{ es_host }}:{{es_port}}/{{ item }}"
         method: "DELETE"
       with_items:
         - "aips"


### PR DESCRIPTION
This removes the hardcoded URL scheme from the reset indexes task. The Elasticsearch scheme is now provided by the application environment variable, so keeping it in the task can result in an invalid endpoint.

Connected to https://github.com/archivematica/Issues/issues/1752