### PR TITLE
Fix debug logging configuration for src layout

### DIFF
--- a/templates/etc/archivematica/storageService.logging.json.j2
+++ b/templates/etc/archivematica/storageService.logging.json.j2
@@ -64,10 +64,7 @@
     }
   },
   "loggers": {
-    "administration": {
-      "level": "DEBUG"
-    },
-    "common": {
+    "archivematica.storage_service": {
       "level": "DEBUG"
     },
     "django.request": {
@@ -79,9 +76,6 @@
     },
     "django.request.tastypie": {
       "level": "ERROR"
-    },
-    "locations": {
-      "level": "DEBUG"
     },
     "sword2": {
       "level": "INFO"


### PR DESCRIPTION
Debug logging was misconfigured because it still targeted legacy short logger names (administration, common, locations) instead of the current archivematica.storage_service.* namespace. This configures a single DEBUG logger for it so application logs are captured consistently.

Related to https://github.com/artefactual/archivematica-storage-service/pull/863