### PR TITLE
Move Prometheus tmpfiles task out of amsrc-configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Note that if something is disabled with the [role variables](#role-variables), i
     - `amsrc-pipeline-instcode`: Install source code
     - `amsrc-pipeline-dbconf`: Configure database
         - `amsrc-pipeline-dbconf-syncdb`: Only run Django's syncdb/migrations
+    - `amsrc-pipeline-tmpfiles`: Install systemd-tmpfiles configuration for AM Prometheus data; can be run independently
     - `amsrc-pipeline-websrv`: Configure webserver
 - `amsrc-automationtools`: Automation tools install
 - `amsrc-configure`: Create SS superuser & create dashboard admin & register pipeline on SS

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,9 @@ archivematica_src_am_mcpclient_instances: 1
 archivematica_src_configure_dashboard: "no"
 archivematica_src_configure_ss: "no"
 
+# Install systemd-tmpfiles config to preserve AM Prometheus stats files.
+archivematica_src_am_prometheus_tmpfiles_enabled: "true"
+
 # Define the type of environment: "production" or "development". The latter will deploy some extra stuff to make the development workflow easier.
 archivematica_src_environment_type: "production"
 
@@ -288,4 +291,3 @@ archivematica_src_remote_locations:
   - { location_purpose: "CP", location_path: "/var/archivematica/sharedDirectory", location_description: "Remote processing", location_default: "true" }
   - { location_purpose: "BL", location_path: "/var/archivematica/sharedDirectory/www/AIPsStore/transferBacklog", location_description: "Remote transfer backlog", location_default: "true" }
 #  - { location_purpose: "TS", location_path: "/home", location_description: "Remote transfer source", location_default: "true" }
-

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -131,13 +131,6 @@
   environment: "{{ archivematica_src_am_dashboard_environment }}"
   when: archivematica_src_configure_dashboard|bool and dashboard_user.stdout == "" and dashboard_ss_url.stdout == ""
 
-# Configure systemd-tmpfiles to not delete AM Prometheus data files.
-- name: "Set up systemd-tmpfiles configuration"
-  template:
-    src: "etc/tmpfiles.d/am-prometheus.conf"
-    dest: "/etc/tmpfiles.d/am-prometheus.conf"
-
-
 #
 #  Configure AtoM DIP Upload
 #

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -280,6 +280,18 @@
 
 
 #
+# Configure AM Prometheus tmpfiles
+#
+
+- import_tasks: "pipeline-tmpfiles.yml"
+  tags:
+    - "amsrc-pipeline"
+    - "amsrc-pipeline-tmpfiles"
+  when:
+    - "archivematica_src_am_prometheus_tmpfiles_enabled|bool"
+
+
+#
 # Remove FITS
 #
 - import_tasks: "fits.yml"

--- a/tasks/pipeline-tmpfiles.yml
+++ b/tasks/pipeline-tmpfiles.yml
@@ -1,0 +1,7 @@
+---
+- name: "Set up systemd-tmpfiles configuration"
+  template:
+    src: "etc/tmpfiles.d/am-prometheus.conf"
+    dest: "/etc/tmpfiles.d/am-prometheus.conf"
+  when:
+    - (ansible_service_mgr | default('')) == "systemd"


### PR DESCRIPTION
This moves the AM Prometheus `systemd-tmpfiles` task so it is
controlled by `archivematica_src_am_prometheus_tmpfiles_enabled`
(default: `true`) and can be run independently with `-t
amsrc-pipeline-tmpfiles`.

Connected to https://github.com/artefactual-labs/ansible-archivematica-src/issues/434