### PR TITLE
Restore WorkingDirectory param in SystemD units

### DIFF
--- a/templates/etc/systemd/system/archivematica-dashboard.service.j2
+++ b/templates/etc/systemd/system/archivematica-dashboard.service.j2
@@ -17,7 +17,7 @@ StandardError=syslog
 SyslogIdentifier=DashboardStdout
 SyslogFacility={{ archivematica_src_syslog_dashboard_facility }}
 {% endif %}
-WorkingDirectory=/var/lib/archivematica
+WorkingDirectory={{ archivematica_src_am_virtualenv }}
 ExecStart={{ archivematica_src_am_virtualenv }}/bin/gunicorn --config {{ archivematica_src_am_dashboard_gunicorn_config }} archivematica.dashboard.wsgi:application
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID

--- a/templates/etc/systemd/system/archivematica-dashboard.service.j2
+++ b/templates/etc/systemd/system/archivematica-dashboard.service.j2
@@ -17,6 +17,7 @@ StandardError=syslog
 SyslogIdentifier=DashboardStdout
 SyslogFacility={{ archivematica_src_syslog_dashboard_facility }}
 {% endif %}
+WorkingDirectory=/var/lib/archivematica
 ExecStart={{ archivematica_src_am_virtualenv }}/bin/gunicorn --config {{ archivematica_src_am_dashboard_gunicorn_config }} archivematica.dashboard.wsgi:application
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID

--- a/templates/etc/systemd/system/archivematica-mcp-client.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-client.service.j2
@@ -21,6 +21,7 @@ StandardError=syslog
 SyslogIdentifier=MCPClientStdout
 SyslogFacility={{ archivematica_src_syslog_mcpclient_facility }}
 {% endif %}
+WorkingDirectory=/var/lib/archivematica
 ExecStart={{ archivematica_src_am_virtualenv }}/bin/python -m archivematica.MCPClient.archivematicaClient
 Restart=always
 RestartSec=30

--- a/templates/etc/systemd/system/archivematica-mcp-client.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-client.service.j2
@@ -21,7 +21,7 @@ StandardError=syslog
 SyslogIdentifier=MCPClientStdout
 SyslogFacility={{ archivematica_src_syslog_mcpclient_facility }}
 {% endif %}
-WorkingDirectory=/var/lib/archivematica
+WorkingDirectory={{ archivematica_src_am_virtualenv }}
 ExecStart={{ archivematica_src_am_virtualenv }}/bin/python -m archivematica.MCPClient.archivematicaClient
 Restart=always
 RestartSec=30

--- a/templates/etc/systemd/system/archivematica-mcp-server.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-server.service.j2
@@ -15,7 +15,7 @@ StandardError=syslog
 SyslogIdentifier=MCPServerStdout
 SyslogFacility={{ archivematica_src_syslog_mcpserver_facility }}
 {% endif %}
-WorkingDirectory=/var/lib/archivematica
+WorkingDirectory={{ archivematica_src_am_virtualenv }}
 ExecStart={{ archivematica_src_am_virtualenv }}/bin/python -m archivematica.MCPServer.archivematicaMCP
 
 [Install]

--- a/templates/etc/systemd/system/archivematica-mcp-server.service.j2
+++ b/templates/etc/systemd/system/archivematica-mcp-server.service.j2
@@ -15,6 +15,7 @@ StandardError=syslog
 SyslogIdentifier=MCPServerStdout
 SyslogFacility={{ archivematica_src_syslog_mcpserver_facility }}
 {% endif %}
+WorkingDirectory=/var/lib/archivematica
 ExecStart={{ archivematica_src_am_virtualenv }}/bin/python -m archivematica.MCPServer.archivematicaMCP
 
 [Install]

--- a/templates/etc/systemd/system/archivematica-storage-service.service.j2
+++ b/templates/etc/systemd/system/archivematica-storage-service.service.j2
@@ -16,6 +16,7 @@ SyslogIdentifier=StorageStdout
 SyslogFacility={{ archivematica_src_syslog_storageservice_facility }}
 {% endif %}
 
+WorkingDirectory=/var/lib/archivematica
 ExecStart={{ archivematica_src_ss_virtualenv }}/bin/gunicorn --config {{ archivematica_src_ss_gunicorn_config }} archivematica.storage_service.storage_service.wsgi:application
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID

--- a/templates/etc/systemd/system/archivematica-storage-service.service.j2
+++ b/templates/etc/systemd/system/archivematica-storage-service.service.j2
@@ -16,7 +16,7 @@ SyslogIdentifier=StorageStdout
 SyslogFacility={{ archivematica_src_syslog_storageservice_facility }}
 {% endif %}
 
-WorkingDirectory=/var/lib/archivematica
+WorkingDirectory={{ archivematica_src_ss_virtualenv }}
 ExecStart={{ archivematica_src_ss_virtualenv }}/bin/gunicorn --config {{ archivematica_src_ss_gunicorn_config }} archivematica.storage_service.storage_service.wsgi:application
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID


### PR DESCRIPTION
This change avoids errors caused by the presence of top-level directories with names matching those of Python modules.

Since the `archivematica_src_am_*_app` variables have been removed, I chose to use the home directory of the `archivematica` user. This is not defined in a variable, so I used the literal value `/var/lib/archivematica`.

Fixes: archivematica/Issues#1795