### PR TITLE
Update get-pip URL for Python 3.9 compatibility

### DIFF
--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -70,7 +70,7 @@
 
   - name: "Download get-pip.py in archivematica userdir"
     get_url:
-      url: "https://bootstrap.pypa.io/get-pip.py"
+      url: "https://bootstrap.pypa.io/pip/3.9/get-pip.py"
       force: "yes"
       dest: "/var/lib/archivematica/get-pip.py"
       owner: "archivematica"


### PR DESCRIPTION
pip 26.1 [removed support for Python 3.9](https://pip.pypa.io/en/stable/news/#v26-1), so this updates the get-pip download URL to use the Python 3.9-specific installer.