### PR TITLE
Fix conditional in configure locations block

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -300,4 +300,6 @@
         - item.location_replication_from is defined
       with_items:
         - "{{ am_ss_default_locations | default({}) }}"
-  when: am_ss_default_locations is defined
+  when:
+    - archivematica_src_configure_ss|bool
+    - am_ss_default_locations is defined


### PR DESCRIPTION
It was running when am_ss_default_locations was defined but it must only be run when it matches and additionaly:

        * archivematica_src_configure_ss=True