### PR TITLE
Adapt AMAUAT dependency installation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ install_rpm_repositories: "true"
 archivematica_src_am_version: "qa/1.x"
 archivematica_src_ss_version: "qa/0.x"
 archivematica_src_automationtools_version: "master"
-archivematica_src_acceptance_tests_version: "master"
+archivematica_src_acceptance_tests_version: "qa/1.x"
 
 # RPM repositories
 archivematica_src_rpm_repositories:
@@ -156,6 +156,10 @@ archivematica_src_ssl_include_acme_chlg_loc: "false"
 
 archivematica_src_pip_version: "25.3"
 archivematica_src_pip_tools_version: "7.5.2"
+
+# uv executable
+
+archivematica_src_uv: "/usr/local/bin/uv"
 
 #
 # Ubuntu mediainfo package

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: An ansible role for installing Archivematica from source.
   company: Artefactual Systems
   license: AGPLv3
-  min_ansible_version: 2.3
+  min_ansible_version: 2.4
   platforms:
   - name: EL
     versions:

--- a/tasks/acceptance-tests.yml
+++ b/tasks/acceptance-tests.yml
@@ -37,15 +37,20 @@
     recurse: true
   tags: "amsrc-ss-pydep"
 
-- name: "Install pip dependencies in virtualenv"
+- name: "Synchronize locked acceptance test dependencies"
   become: "yes"
   become_user: "archivematica"
-  pip:
+  command: >-
+    make sync-runtime
+    UV={{ archivematica_src_uv }}
+  register: "__archivematica_src_acceptance_tests_sync"
+  changed_when: >-
+    'Installed ' in __archivematica_src_acceptance_tests_sync.stderr or
+    'Uninstalled ' in __archivematica_src_acceptance_tests_sync.stderr
+  args:
     chdir: "{{ archivematica_src_dir }}/archivematica-acceptance-tests"
-    requirements: "requirements.txt"
-    virtualenv: "/usr/share/archivematica/virtualenvs/archivematica-acceptance-tests"
-    virtualenv_command: "{{ archivematica_src_virtualenv }}"
-    state: latest
+  environment:
+    UV_PROJECT_ENVIRONMENT: "/usr/share/archivematica/virtualenvs/archivematica-acceptance-tests"
 
 #
 # Install Firefox

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -142,6 +142,9 @@
        archivematica_src_install_am|bool or
        archivematica_src_install_am=='rpm'"
 
+- import_tasks: "uv.yml"
+  tags: "always"
+
 
 - name: "Checkout out archivematica-sampledata repository"
   git:

--- a/tasks/uv.yml
+++ b/tasks/uv.yml
@@ -1,0 +1,216 @@
+---
+
+- name: "Resolve uv release asset"
+  set_fact:
+    __archivematica_src_uv_release_filename: "{{ __archivematica_src_uv_architecture_map.get(ansible_architecture) }}"
+  vars:
+    __archivematica_src_uv_architecture_map:
+      x86_64: "uv-x86_64-unknown-linux-gnu.tar.gz"
+      amd64: "uv-x86_64-unknown-linux-gnu.tar.gz"
+      aarch64: "uv-aarch64-unknown-linux-gnu.tar.gz"
+      arm64: "uv-aarch64-unknown-linux-gnu.tar.gz"
+      armv7: "uv-armv7-unknown-linux-gnueabihf.tar.gz"
+      armv7l: "uv-armv7-unknown-linux-gnueabihf.tar.gz"
+      i386: "uv-i686-unknown-linux-gnu.tar.gz"
+      i486: "uv-i686-unknown-linux-gnu.tar.gz"
+      i586: "uv-i686-unknown-linux-gnu.tar.gz"
+      i686: "uv-i686-unknown-linux-gnu.tar.gz"
+      ppc64le: "uv-powerpc64le-unknown-linux-gnu.tar.gz"
+      powerpc64le: "uv-powerpc64le-unknown-linux-gnu.tar.gz"
+      riscv64: "uv-riscv64gc-unknown-linux-gnu.tar.gz"
+      s390x: "uv-s390x-unknown-linux-gnu.tar.gz"
+
+- name: "Fail when uv architecture is unsupported"
+  fail:
+    msg: >-
+      Unsupported architecture {{ ansible_architecture }}. Supported options
+      are x86_64/amd64, aarch64/arm64, armv7/armv7l, i386/i486/i586/i686,
+      ppc64le/powerpc64le, riscv64, and s390x.
+  when: not __archivematica_src_uv_release_filename
+
+- name: "Check for existing uv path"
+  stat:
+    path: "{{ archivematica_src_uv }}"
+    get_checksum: no
+    get_mime: no
+    get_attributes: no
+  register: "__archivematica_src_uv_binary"
+
+- name: "Validate existing uv path"
+  assert:
+    that:
+      - >-
+        __archivematica_src_uv_binary.stat.isreg or
+        __archivematica_src_uv_binary.stat.islnk
+    msg: >-
+      The existing uv path {{ archivematica_src_uv }} is not a regular file or
+      symbolic link.
+  when: __archivematica_src_uv_binary.stat.exists
+
+- name: "Ensure existing uv binary permissions"
+  file:
+    path: "{{ archivematica_src_uv }}"
+    state: "file"
+    mode: "0755"
+  when: __archivematica_src_uv_binary.stat.isreg | default(false)
+
+- name: "Validate existing uv symbolic link"
+  assert:
+    that:
+      - __archivematica_src_uv_binary.stat.executable
+    msg: >-
+      The existing uv symbolic link {{ archivematica_src_uv }} does not resolve
+      to an executable file.
+  when: __archivematica_src_uv_binary.stat.islnk | default(false)
+
+- name: "Resolve latest uv release"
+  uri:
+    url: "https://github.com/astral-sh/uv/releases/latest"
+    method: "HEAD"
+    follow_redirects: "all"
+    status_code: 200
+    timeout: 30
+  register: "__archivematica_src_uv_latest_release"
+  retries: 3
+  delay: 3
+  until: __archivematica_src_uv_latest_release is success
+  changed_when: false
+  check_mode: no
+
+- name: "Record latest uv release"
+  set_fact:
+    __archivematica_src_uv_latest_tag: >-
+      {{ __archivematica_src_uv_latest_release.url | basename }}
+    __archivematica_src_uv_latest_version: >-
+      {{ (__archivematica_src_uv_latest_release.url | basename) | regex_replace('^v', '') }}
+
+- name: "Query installed uv version"
+  command: "{{ archivematica_src_uv }} --version"
+  register: "__archivematica_src_uv_installed_version_command"
+  changed_when: false
+  failed_when: false
+  check_mode: no
+
+- name: "Record installed uv version"
+  set_fact:
+    __archivematica_src_uv_installed_version: >-
+      {{ __archivematica_src_uv_installed_version_command.stdout.split()[1]
+         if __archivematica_src_uv_installed_version_command.rc == 0 and
+         (__archivematica_src_uv_installed_version_command.stdout.split() | length) > 1
+         else '' }}
+
+- name: "Determine whether uv installation is required"
+  set_fact:
+    __archivematica_src_uv_install_required: >-
+      {{ __archivematica_src_uv_installed_version != __archivematica_src_uv_latest_version }}
+
+- name: "Report required uv installation in check mode"
+  debug:
+    msg: >-
+      uv {{ __archivematica_src_uv_latest_version }} would be installed at
+      {{ archivematica_src_uv }}.
+  changed_when: true
+  when:
+    - __archivematica_src_uv_install_required
+    - ansible_check_mode
+
+- name: "Ensure uv install directory exists"
+  file:
+    path: "{{ archivematica_src_uv | dirname }}"
+    state: "directory"
+    mode: "0755"
+  when: __archivematica_src_uv_install_required
+
+- name: "Install latest uv release"
+  block:
+    - name: "Create temporary directory for uv download"
+      tempfile:
+        state: "directory"
+        suffix: "-uv-download"
+      register: "__archivematica_src_uv_tempdir"
+
+    - name: "Set uv download variables"
+      set_fact:
+        __archivematica_src_uv_archive_url: >-
+          https://github.com/astral-sh/uv/releases/download/{{ __archivematica_src_uv_latest_tag }}/{{ __archivematica_src_uv_release_filename }}
+        __archivematica_src_uv_checksum_url: >-
+          https://github.com/astral-sh/uv/releases/download/{{ __archivematica_src_uv_latest_tag }}/{{ __archivematica_src_uv_release_filename }}.sha256
+        __archivematica_src_uv_archive_path: >-
+          {{ __archivematica_src_uv_tempdir.path }}/{{ __archivematica_src_uv_release_filename }}
+        __archivematica_src_uv_checksum_path: >-
+          {{ __archivematica_src_uv_tempdir.path }}/{{ __archivematica_src_uv_release_filename }}.sha256
+        __archivematica_src_uv_extracted_binary_path: >-
+          {{ __archivematica_src_uv_tempdir.path }}/{{ __archivematica_src_uv_release_filename | regex_replace('[.]tar[.]gz$', '') }}/uv
+
+    - name: "Download uv checksum"
+      get_url:
+        url: "{{ __archivematica_src_uv_checksum_url }}"
+        dest: "{{ __archivematica_src_uv_checksum_path }}"
+        mode: "0644"
+        timeout: 30
+      register: "__archivematica_src_uv_checksum_download"
+      retries: 3
+      delay: 3
+      until: __archivematica_src_uv_checksum_download is success
+
+    - name: "Read uv checksum file"
+      slurp:
+        src: "{{ __archivematica_src_uv_checksum_path }}"
+      register: "__archivematica_src_uv_checksum_file"
+
+    - name: "Record expected uv checksum"
+      set_fact:
+        __archivematica_src_uv_expected_checksum: >-
+          {{ (__archivematica_src_uv_checksum_file.content | b64decode).split()[0] }}
+
+    - name: "Download uv archive"
+      get_url:
+        url: "{{ __archivematica_src_uv_archive_url }}"
+        dest: "{{ __archivematica_src_uv_archive_path }}"
+        mode: "0644"
+        checksum: "sha256:{{ __archivematica_src_uv_expected_checksum }}"
+        timeout: 30
+      register: "__archivematica_src_uv_archive_download"
+      retries: 3
+      delay: 3
+      until: __archivematica_src_uv_archive_download is success
+
+    - name: "Extract uv archive"
+      unarchive:
+        src: "{{ __archivematica_src_uv_archive_path }}"
+        dest: "{{ __archivematica_src_uv_tempdir.path }}"
+        remote_src: yes
+        mode: "0755"
+
+    - name: "Check extracted uv binary"
+      stat:
+        path: "{{ __archivematica_src_uv_extracted_binary_path }}"
+      register: "__archivematica_src_uv_extracted_binary"
+
+    - name: "Ensure uv binary exists in archive"
+      assert:
+        that:
+          - __archivematica_src_uv_extracted_binary.stat.isreg
+          - __archivematica_src_uv_extracted_binary.stat.executable
+        msg: >-
+          An executable uv binary was not found at
+          {{ __archivematica_src_uv_extracted_binary_path }}.
+
+    - name: "Install uv binary"
+      copy:
+        src: "{{ __archivematica_src_uv_extracted_binary_path }}"
+        dest: "{{ archivematica_src_uv }}"
+        remote_src: yes
+        follow: no
+        mode: "0755"
+  always:
+    - name: "Remove temporary uv download directory"
+      file:
+        path: "{{ __archivematica_src_uv_tempdir.path }}"
+        state: "absent"
+      when:
+        - __archivematica_src_uv_tempdir is defined
+        - __archivematica_src_uv_tempdir.path is defined
+  when:
+    - __archivematica_src_uv_install_required
+    - not ansible_check_mode

--- a/vars/AlmaLinux-9.yml
+++ b/vars/AlmaLinux-9.yml
@@ -12,7 +12,8 @@ ansible_deps:
   - "python3-libsemanage"     # Required by SELinux management
   - "ca-certificates"         # Required for yum
 ca_custom_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
-archivematica_src_am_amauat_deps: []
+archivematica_src_am_amauat_deps:
+  - "make"
 archivematica_src_am_fixity_deps:
   - "sqlite"
   - "moreutils"

--- a/vars/OracleLinux-9.yml
+++ b/vars/OracleLinux-9.yml
@@ -12,7 +12,8 @@ ansible_deps:
   - "python3-libsemanage"     # Required by SELinux management
   - "ca-certificates"         # Required for yum
 ca_custom_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
-archivematica_src_am_amauat_deps: []
+archivematica_src_am_amauat_deps:
+  - "make"
 archivematica_src_am_fixity_deps:
   - "sqlite"
   - "moreutils"

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -12,7 +12,8 @@ ansible_deps:
   - "python3-libsemanage"     # Required by SELinux management
   - "ca-certificates"         # Required for yum
 ca_custom_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
-archivematica_src_am_amauat_deps: []
+archivematica_src_am_amauat_deps:
+  - "make"
 archivematica_src_am_fixity_deps:
   - "sqlite"
   - "moreutils"

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -12,7 +12,8 @@ ansible_deps:
   - "python3-libsemanage"     # Required by SELinux management
   - "ca-certificates"         # Required for yum
 ca_custom_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
-archivematica_src_am_amauat_deps: []
+archivematica_src_am_amauat_deps:
+  - "make"
 archivematica_src_am_fixity_deps:
   - "sqlite"
   - "moreutils"

--- a/vars/Rocky-8.yml
+++ b/vars/Rocky-8.yml
@@ -12,7 +12,8 @@ ansible_deps:
   - "python3-libsemanage"     # Required by SELinux management
   - "ca-certificates"         # Required for yum
 ca_custom_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
-archivematica_src_am_amauat_deps: []
+archivematica_src_am_amauat_deps:
+  - "make"
 archivematica_src_am_fixity_deps:
   - "sqlite"
   - "moreutils"

--- a/vars/Rocky-9.yml
+++ b/vars/Rocky-9.yml
@@ -12,7 +12,8 @@ ansible_deps:
   - "python3-libsemanage"     # Required by SELinux management
   - "ca-certificates"         # Required for yum
 ca_custom_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
-archivematica_src_am_amauat_deps: []
+archivematica_src_am_amauat_deps:
+  - "make"
 archivematica_src_am_fixity_deps:
   - "sqlite"
   - "moreutils"

--- a/vars/Ubuntu-22.yml
+++ b/vars/Ubuntu-22.yml
@@ -13,6 +13,7 @@ ca_custom_bundle: "/etc/ssl/certs/ca-certificates.crt"
 archivematica_src_am_amauat_deps:
   - "tightvncserver"
   - "icewm"
+  - "make"
 archivematica_src_am_fixity_deps:
   - "sqlite3"
   - "moreutils"

--- a/vars/Ubuntu-24.yml
+++ b/vars/Ubuntu-24.yml
@@ -13,6 +13,7 @@ ca_custom_bundle: "/etc/ssl/certs/ca-certificates.crt"
 archivematica_src_am_amauat_deps:
   - "tightvncserver"
   - "icewm"
+  - "make"
 archivematica_src_am_fixity_deps:
   - "sqlite3"
   - "moreutils"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,7 +7,8 @@ archivematica_src_am_dashboard_gunicorn_config: "/etc/archivematica/dashboard.gu
 archivematica_src_ss_virtualenv: "/usr/share/archivematica/virtualenvs/archivematica-storage-service"
 archivematica_src_ss_gunicorn_config: "/etc/archivematica/storage-service.gunicorn-config.py"
 
-archivematica_src_am_amauat_deps: []
+archivematica_src_am_amauat_deps:
+  - "make"
 archivematica_src_am_fixity_deps: []
 
 archivematica_src_virtualenv: "{{ archivematica_src_virtualenv_python }} -m venv"


### PR DESCRIPTION
Install the latest uv release globally with checksum verification and reuse it across role-managed projects. Provision acceptance-test runtime dependencies through the `sync-runtime` Make target.