### PR TITLE
Adopt uv for Archivematica dependencies

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -152,11 +152,6 @@ archivematica_src_ssl_include_acme_chlg_loc: "false"
 # Other components
 #
 
-# Pip version
-
-archivematica_src_pip_version: "25.3"
-archivematica_src_pip_tools_version: "7.5.2"
-
 # uv executable
 
 archivematica_src_uv: "/usr/local/bin/uv"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -215,7 +215,7 @@
 #
 #   0- Clone source repo
 #   1- OS dependencies (debian packages)
-#   2- python dependencies (pip packages)
+#   2- Python dependencies
 #   3- OS configuration (user/directory/file creation/permissions/ownership)
 #   4- Code install
 #   5- Database config
@@ -231,6 +231,30 @@
     tags:
       - "amsrc-pipeline"
       - "amsrc-pipeline-osdeps"
+
+  # Keep this task in the shared pipeline block so dependency synchronization
+  # and code installation can each be run by tag while a full install performs
+  # the recursive ownership change only once.
+  #
+  # TODO: Stop making the runtime service account the owner of the entire
+  # source root. This grants compromised services write access to application
+  # code and Git metadata for every checkout under archivematica_src_dir,
+  # allowing persistent code changes or malicious Git hooks. Later privileged
+  # Git operations or management commands could execute those changes. Replace
+  # this with a dedicated unprivileged deployment user and narrowly scoped
+  # writable build paths, keeping source code and Git metadata read-only to
+  # runtime services.
+  - name: "Change archivematica source owner to archivematica"
+    file:
+      dest: "{{ archivematica_src_dir }}"
+      state: "directory"
+      owner: "archivematica"
+      group: "archivematica"
+      recurse: "yes"
+    tags:
+      - "amsrc-pipeline"
+      - "amsrc-pipeline-pipdeps"
+      - "amsrc-pipeline-instcode"
 
   - import_tasks: "pipeline-pip-deps.yml"
     tags:

--- a/tasks/pipeline-instcode.yml
+++ b/tasks/pipeline-instcode.yml
@@ -4,24 +4,6 @@
 #   4- Code install
 ###########################################################
 
-- name: "Change archivematica-source owner to archivematica"
-  file:
-    dest: "{{ archivematica_src_dir }}"
-    state: "directory"
-    owner: "archivematica"
-    group: "archivematica"
-    recurse: "yes"
-
-- name: "Install archivematica Python package"
-  become: "yes"
-  become_user: "archivematica"
-  pip:
-    virtualenv: "{{ archivematica_src_am_virtualenv }}"
-    chdir: "{{ archivematica_src_dir }}/archivematica"
-    name: .
-    editable: yes
-    extra_args: "--no-deps"
-
 - name: "Copy gunicorn configuration file"
   copy:
     src: "{{ archivematica_src_dir }}/archivematica/src/archivematica/dashboard/install/dashboard.gunicorn-config.py"

--- a/tasks/pipeline-pip-deps.yml
+++ b/tasks/pipeline-pip-deps.yml
@@ -24,22 +24,21 @@
     state: "directory"
     recurse: true
 
-- name: "Create virtualenv and install pip-tools"
+- name: "Synchronize locked Archivematica dependencies"
   become: "yes"
   become_user: "archivematica"
-  pip:
-    virtualenv: "{{ archivematica_src_am_virtualenv }}"
-    virtualenv_command: "{{ archivematica_src_virtualenv }}"
-    name: 
-      - "pip=={{ archivematica_src_pip_version }}"
-      - "pip-tools=={{ archivematica_src_pip_tools_version }}"
-
-- name: "Synchronize requirements"
-  become: "yes"
-  become_user: "archivematica"
-  command: "{{ archivematica_src_am_virtualenv }}/bin/pip-sync {{ 'requirements-dev.txt' if is_dev else 'requirements.txt' }}"
+  command: >-
+    make {{ 'sync' if is_dev else 'sync-runtime' }}
+    UV={{ archivematica_src_uv }}
+  register: "__archivematica_src_am_sync"
+  changed_when: >-
+    'Installed ' in __archivematica_src_am_sync.stderr or
+    'Uninstalled ' in __archivematica_src_am_sync.stderr
   args:
     chdir: "{{ archivematica_src_dir }}/archivematica"
   environment:
     LC_ALL: "en_US.utf8"
     LANG: "en_US.utf8"
+    UV_PROJECT_ENVIRONMENT: "{{ archivematica_src_am_virtualenv }}"
+    UV_PYTHON: "{{ archivematica_src_virtualenv_python }}"
+    UV_PYTHON_DOWNLOADS: "never"

--- a/vars/AlmaLinux-9.yml
+++ b/vars/AlmaLinux-9.yml
@@ -31,6 +31,7 @@ dashboard_osdeps:
     - gcc
     - gcc-c++
     - gettext    # only required in development environments (used to make string translateable)
+    - make
     - nginx
     - python3-policycoreutils
     - libffi-devel

--- a/vars/OracleLinux-9.yml
+++ b/vars/OracleLinux-9.yml
@@ -31,6 +31,7 @@ dashboard_osdeps:
     - gcc
     - gcc-c++
     - gettext    # only required in development environments (used to make string translateable)
+    - make
     - nginx
     - python3-policycoreutils
     - libffi-devel

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -33,6 +33,7 @@ dashboard_osdeps:
     - gcc
     - gcc-c++
     - gettext    # only required in development environments (used to make string translateable)
+    - make
     - nginx
     - python3-policycoreutils
     - libffi-devel

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -31,6 +31,7 @@ dashboard_osdeps:
     - gcc
     - gcc-c++
     - gettext    # only required in development environments (used to make string translateable)
+    - make
     - nginx
     - python3-policycoreutils
     - libffi-devel

--- a/vars/Rocky-8.yml
+++ b/vars/Rocky-8.yml
@@ -33,6 +33,7 @@ dashboard_osdeps:
     - gcc
     - gcc-c++
     - gettext    # only required in development environments (used to make string translateable)
+    - make
     - nginx
     - python3-policycoreutils
     - libffi-devel

--- a/vars/Rocky-9.yml
+++ b/vars/Rocky-9.yml
@@ -31,6 +31,7 @@ dashboard_osdeps:
     - gcc
     - gcc-c++
     - gettext    # only required in development environments (used to make string translateable)
+    - make
     - nginx
     - python3-policycoreutils
     - libffi-devel

--- a/vars/Ubuntu-22.yml
+++ b/vars/Ubuntu-22.yml
@@ -32,6 +32,7 @@ dashboard_osdeps:
     - gcc
     - g++
     - gettext
+    - make
     - nginx
     - libffi-dev
     - libxml2-dev

--- a/vars/Ubuntu-24.yml
+++ b/vars/Ubuntu-24.yml
@@ -32,6 +32,7 @@ dashboard_osdeps:
     - gcc
     - g++
     - gettext
+    - make
     - nginx
     - libffi-dev
     - libxml2-dev


### PR DESCRIPTION
Synchronize Archivematica's locked development or runtime environment through its Makefile. Remove pip-tools bootstrapping and the redundant editable install.